### PR TITLE
[ASSIST-535]: Remove display of GUID 'ID' from service management record view, [ASSIST-545]: Remove display of GUID 'ID' from audit list view and record view.

### DIFF
--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
@@ -5,6 +5,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\Pages;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Assist\Alert\Enums\AlertStatus;
 use Assist\Alert\Enums\AlertSeverity;
 use Filament\Forms\Components\Select;
@@ -99,6 +100,7 @@ class ManageStudentAlerts extends ManageRelatedRecords
         return $table
             ->recordTitleAttribute('description')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('description')
                     ->limit(),
                 TextColumn::make('severity')

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentSubscriptions.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentSubscriptions.php
@@ -4,6 +4,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\Pages;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use App\Filament\Resources\UserResource;
@@ -44,6 +45,7 @@ class ManageStudentSubscriptions extends ManageRelatedRecords
         return $table
             ->recordTitleAttribute('user.name')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('user.name')
                     ->url(fn ($record) => UserResource::getUrl('view', ['record' => $record->user]))
                     ->color('primary'),

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentTasks.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentTasks.php
@@ -6,6 +6,7 @@ use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Assist\Task\Models\Task;
 use Assist\Task\Enums\TaskStatus;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Filters\Filter;
 use Assist\Prospect\Models\Prospect;
 use Filament\Forms\Components\Select;
@@ -65,6 +66,7 @@ class ManageStudentTasks extends ManageRelatedRecords
         return $table
             ->recordTitleAttribute('description')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('description')
                     ->searchable()
                     ->wrap()

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementFilesRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementFilesRelationManager.php
@@ -6,6 +6,7 @@ use Filament\Forms;
 use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -34,6 +35,7 @@ class EngagementFilesRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('description')
             ->columns([
+                IdColumn::make(),
                 Tables\Columns\TextColumn::make('description'),
                 SpatieMediaLibraryImageColumn::make('file')
                     ->collection('file')

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementResponsesRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementResponsesRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\RelationMana
 
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Infolists\Components\TextEntry;
@@ -29,7 +30,7 @@ class EngagementResponsesRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('id')
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('content'),
                 TextColumn::make('sent_at')
                     ->dateTime('Y-m-d H:i:s'),

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -5,6 +5,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\RelationMana
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Forms\Components\Hidden;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -84,7 +85,7 @@ class EngagementsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('id')
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('subject'),
                 TextColumn::make('body'),
                 TextColumn::make('channels')

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EnrollmentsRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EnrollmentsRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\RelationMana
 
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Infolists\Components\TextEntry;
@@ -39,6 +40,7 @@ class EnrollmentsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('division')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('division')
                     ->label('College'),
                 TextColumn::make('class_nbr')

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/PerformanceRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/PerformanceRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\RelationMana
 
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -46,6 +47,7 @@ class PerformanceRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('acad_career')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('acad_career')
                     ->label('Academic Career'),
                 TextColumn::make('division')

--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/ProgramsRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/ProgramsRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\AssistDataModel\Filament\Resources\StudentResource\RelationMana
 
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Infolists\Components\TextEntry;
@@ -16,26 +17,24 @@ class ProgramsRelationManager extends RelationManager
     public function infolist(Infolist $infolist): Infolist
     {
         return parent::infolist($infolist)
-            ->schema(
-                [
-                    TextEntry::make('sisid')
-                        ->label('SISID'),
-                    TextEntry::make('otherid')
-                        ->label('STUID'),
-                    TextEntry::make('division')
-                        ->label('College'),
-                    TextEntry::make('descr')
-                        ->label('Program'),
-                    TextEntry::make('foi')
-                        ->label('Field of Interest'),
-                    TextEntry::make('cum_gpa')
-                        ->label('Cumulative GPA'),
-                    TextEntry::make('declare_dt')
-                        ->label('Start Date'),
-                    TextEntry::make('change_dt')
-                        ->label('Last Action Date'),
-                ]
-            );
+            ->schema([
+                TextEntry::make('sisid')
+                    ->label('SISID'),
+                TextEntry::make('otherid')
+                    ->label('STUID'),
+                TextEntry::make('division')
+                    ->label('College'),
+                TextEntry::make('descr')
+                    ->label('Program'),
+                TextEntry::make('foi')
+                    ->label('Field of Interest'),
+                TextEntry::make('cum_gpa')
+                    ->label('Cumulative GPA'),
+                TextEntry::make('declare_dt')
+                    ->label('Start Date'),
+                TextEntry::make('change_dt')
+                    ->label('Last Action Date'),
+            ]);
     }
 
     public function table(Table $table): Table
@@ -43,6 +42,7 @@ class ProgramsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('descr')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('otherid')
                     ->label('STUID'),
                 TextColumn::make('division')

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -5,6 +5,7 @@ namespace Assist\Audit\Filament\Resources\AuditResource\Pages;
 use App\Models\User;
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -21,9 +22,7 @@ class ListAudits extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('auditable_type')
                     ->label('Auditable')
                     ->sortable(),

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
@@ -19,8 +19,6 @@ class ViewAudit extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID'),
                         TextEntry::make('auditable_type')
                             ->label('Auditable'),
                         TextEntry::make('user.name')

--- a/app-modules/authorization/src/Filament/Resources/PermissionResource.php
+++ b/app-modules/authorization/src/Filament/Resources/PermissionResource.php
@@ -5,6 +5,7 @@ namespace Assist\Authorization\Filament\Resources;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Resources\Resource;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
@@ -40,6 +41,7 @@ class PermissionResource extends Resource
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
                 TextColumn::make('guard_name')

--- a/app-modules/authorization/src/Filament/Resources/PermissionResource/Pages/ListPermissions.php
+++ b/app-modules/authorization/src/Filament/Resources/PermissionResource/Pages/ListPermissions.php
@@ -2,9 +2,9 @@
 
 namespace Assist\Authorization\Filament\Resources\PermissionResource\Pages;
 
+use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
-use Filament\Resources\Pages\ListRecords\Tab;
 use Assist\Authorization\Filament\Resources\PermissionResource;
 
 class ListPermissions extends ListRecords

--- a/app-modules/authorization/src/Filament/Resources/PermissionResource/RelationManagers/RolesRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/PermissionResource/RelationManagers/RolesRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Authorization\Filament\Resources\PermissionResource\RelationMan
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -28,6 +29,7 @@ class RolesRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
             ])
             ->filters([

--- a/app-modules/authorization/src/Filament/Resources/RoleGroupResource.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleGroupResource.php
@@ -5,6 +5,7 @@ namespace Assist\Authorization\Filament\Resources;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Resources\Resource;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -51,6 +52,7 @@ class RoleGroupResource extends Resource
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
                 TextColumn::make('created_at')

--- a/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/PermissionsRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/PermissionsRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Authorization\Filament\Resources\RoleGroupResource\RelationMana
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -31,6 +32,7 @@ class PermissionsRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('guard_name'),
             ])

--- a/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/RolesRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/RolesRelationManager.php
@@ -5,6 +5,7 @@ namespace Assist\Authorization\Filament\Resources\RoleGroupResource\RelationMana
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
@@ -37,6 +38,7 @@ class RolesRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('guard_name'),
             ])

--- a/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/UsersRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/UsersRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Authorization\Filament\Resources\RoleGroupResource\RelationMana
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Actions\AttachAction;
@@ -30,6 +31,7 @@ class UsersRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('email'),
             ])

--- a/app-modules/authorization/src/Filament/Resources/RoleResource.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource.php
@@ -5,6 +5,7 @@ namespace Assist\Authorization\Filament\Resources;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Resources\Resource;
+use App\Filament\Columns\IdColumn;
 use Assist\Authorization\Models\Role;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -43,6 +44,7 @@ class RoleResource extends Resource
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
                 TextColumn::make('guard_name')

--- a/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
@@ -3,8 +3,8 @@
 namespace Assist\Authorization\Filament\Resources\RoleResource\Pages;
 
 use Filament\Actions\CreateAction;
+use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
-use Filament\Resources\Pages\ListRecords\Tab;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Assist\Authorization\Filament\Resources\RoleResource;
 

--- a/app-modules/authorization/src/Filament/Resources/RoleResource/RelationManagers/PermissionsRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/RelationManagers/PermissionsRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Authorization\Filament\Resources\RoleResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
@@ -33,6 +34,7 @@ class PermissionsRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
             ])
             ->filters([

--- a/app-modules/caseload-management/src/Filament/Resources/CaseloadResource/Pages/ListCaseloads.php
+++ b/app-modules/caseload-management/src/Filament/Resources/CaseloadResource/Pages/ListCaseloads.php
@@ -3,6 +3,7 @@
 namespace Assist\CaseloadManagement\Filament\Resources\CaseloadResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Actions\EditAction;
@@ -19,6 +20,7 @@ class ListCaseloads extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->sortable(),
                 TextColumn::make('model')

--- a/app-modules/consent/src/Filament/Resources/ConsentAgreementResource/Pages/ListConsentAgreements.php
+++ b/app-modules/consent/src/Filament/Resources/ConsentAgreementResource/Pages/ListConsentAgreements.php
@@ -3,6 +3,7 @@
 namespace Assist\Consent\Filament\Resources\ConsentAgreementResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -16,6 +17,7 @@ class ListConsentAgreements extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('type'),
                 TextColumn::make('title'),
             ])

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/ListDivisions.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/ListDivisions.php
@@ -3,6 +3,7 @@
 namespace Assist\Division\Filament\Resources\DivisionResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
@@ -21,6 +22,7 @@ class ListDivisions extends ListRecords
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->sortable()
                     ->searchable(),

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/ViewDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/ViewDivision.php
@@ -21,8 +21,6 @@ class ViewDivision extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID'),
                         TextEntry::make('name'),
                         TextEntry::make('code'),
                         Section::make()

--- a/app-modules/engagement/src/Filament/Resources/EngagementFileResource/Pages/ListEngagementFiles.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementFileResource/Pages/ListEngagementFiles.php
@@ -4,6 +4,7 @@ namespace Assist\Engagement\Filament\Resources\EngagementFileResource\Pages;
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -20,9 +21,7 @@ class ListEngagementFiles extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('description')
                     ->label('Description')
                     ->searchable()

--- a/app-modules/engagement/src/Filament/Resources/EngagementFileResource/Pages/ViewEngagementFile.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementFileResource/Pages/ViewEngagementFile.php
@@ -21,8 +21,6 @@ class ViewEngagementFile extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID'),
                         TextEntry::make('description')
                             ->label('Description'),
                         SpatieMediaLibraryImageEntry::make('file')

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/ListEngagements.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/ListEngagements.php
@@ -3,6 +3,7 @@
 namespace Assist\Engagement\Filament\Resources\EngagementResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
@@ -21,6 +22,7 @@ class ListEngagements extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('user.name')
                     ->label('Created By'),
                 TextColumn::make('subject'),

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/ViewEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/ViewEngagement.php
@@ -26,9 +26,6 @@ class ViewEngagement extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('user.name')
                             ->label('Created By')
                             ->translateLabel()

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/EngagementDeliverablesRelationManager.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/EngagementDeliverablesRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Engagement\Filament\Resources\EngagementResource\RelationManage
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Forms\Components\Select;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -40,6 +41,7 @@ class EngagementDeliverablesRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('channel')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('channel'),
                 IconColumn::make('delivery_status')
                     ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/UserRelationManager.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/UserRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Engagement\Filament\Resources\EngagementResource\RelationManage
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -27,6 +28,7 @@ class UserRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('name')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
             ])
             ->filters([

--- a/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ListEngagementResponses.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ListEngagementResponses.php
@@ -3,6 +3,7 @@
 namespace Assist\Engagement\Filament\Resources\EngagementResponseResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -16,8 +17,7 @@ class ListEngagementResponses extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->translateLabel(),
+                IdColumn::make(),
                 TextColumn::make('content')
                     ->translateLabel(),
             ])

--- a/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ViewEngagementResponse.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ViewEngagementResponse.php
@@ -23,9 +23,6 @@ class ViewEngagementResponse extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('sender')
                             ->label('Sent By')
                             ->translateLabel()

--- a/app-modules/form/src/Filament/Resources/FormResource/Pages/ListForms.php
+++ b/app-modules/form/src/Filament/Resources/FormResource/Pages/ListForms.php
@@ -4,6 +4,7 @@ namespace Assist\Form\Filament\Resources\FormResource\Pages;
 
 use Filament\Tables\Table;
 use Assist\Form\Models\Form;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\EditAction;
@@ -21,6 +22,7 @@ class ListForms extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
             ])
             ->filters([

--- a/app-modules/form/src/Filament/Resources/FormResource/RelationManagers/FormSubmissionsRelationManager.php
+++ b/app-modules/form/src/Filament/Resources/FormResource/RelationManagers/FormSubmissionsRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Form\Filament\Resources\FormResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Forms\Components\KeyValue;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -30,7 +31,7 @@ class FormSubmissionsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('id')
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('created_at')
                     ->sortable(),
             ])

--- a/app-modules/integration-google-analytics/src/Filament/Pages/ManageGoogleAnalyticsSettings.php
+++ b/app-modules/integration-google-analytics/src/Filament/Pages/ManageGoogleAnalyticsSettings.php
@@ -29,7 +29,8 @@ class ManageGoogleAnalyticsSettings extends SettingsPage
             ->columns(1)
             ->schema([
                 Toggle::make('is_enabled')
-                    ->label('Enabled'),
+                    ->label('Enabled')
+                    ->live(),
                 TextInput::make('id')
                     ->visible(fn (Get $get) => $get('is_enabled')),
                 // TODO: add key value options?

--- a/app-modules/integration-microsoft-clarity/src/Filament/Pages/ManageMicrosoftClaritySettings.php
+++ b/app-modules/integration-microsoft-clarity/src/Filament/Pages/ManageMicrosoftClaritySettings.php
@@ -29,7 +29,8 @@ class ManageMicrosoftClaritySettings extends SettingsPage
             ->columns(1)
             ->schema([
                 Toggle::make('is_enabled')
-                    ->label('Enabled'),
+                    ->label('Enabled')
+                    ->live(),
                 TextInput::make('id')
                     ->visible(fn (Get $get) => $get('is_enabled')),
             ]);

--- a/app-modules/interaction/src/Filament/Resources/InteractionCampaignResource/Pages/ListInteractionCampaigns.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionCampaignResource/Pages/ListInteractionCampaigns.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionCampaignResource\Page
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListInteractionCampaigns extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
             ])

--- a/app-modules/interaction/src/Filament/Resources/InteractionDriverResource/Pages/ListInteractionDrivers.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionDriverResource/Pages/ListInteractionDrivers.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionDriverResource\Pages;
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListInteractionDrivers extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
             ])

--- a/app-modules/interaction/src/Filament/Resources/InteractionInstitutionResource/Pages/ListInteractionInstitutions.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionInstitutionResource/Pages/ListInteractionInstitutions.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionInstitutionResource\P
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListInteractionInstitutions extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
             ])

--- a/app-modules/interaction/src/Filament/Resources/InteractionOutcomeResource/Pages/ListInteractionOutcomes.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionOutcomeResource/Pages/ListInteractionOutcomes.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionOutcomeResource\Pages
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListInteractionOutcomes extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
             ])

--- a/app-modules/interaction/src/Filament/Resources/InteractionRelationResource/Pages/ListInteractionRelations.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionRelationResource/Pages/ListInteractionRelations.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionRelationResource\Page
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListInteractionRelations extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
             ])

--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/ListInteractions.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/ListInteractions.php
@@ -5,6 +5,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionResource\Pages;
 use Filament\Actions;
 use Filament\Tables\Table;
 use Carbon\CarbonInterface;
+use App\Filament\Columns\IdColumn;
 use App\Filament\Actions\ImportAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
@@ -24,7 +25,7 @@ class ListInteractions extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('campaign.name')
                     ->searchable(),
                 TextColumn::make('driver.name')

--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/RelationManagers/HasManyMorphedInteractionsRelationManager.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/RelationManagers/HasManyMorphedInteractionsRelationManager.php
@@ -5,6 +5,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionResource\RelationMana
 use Filament\Tables\Table;
 use Carbon\CarbonInterface;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -56,7 +57,7 @@ class HasManyMorphedInteractionsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('id')
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('campaign.name'),
                 TextColumn::make('driver.name'),
                 TextColumn::make('institution.name'),

--- a/app-modules/interaction/src/Filament/Resources/InteractionStatusResource/Pages/ListInteractionStatuses.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionStatusResource/Pages/ListInteractionStatuses.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionStatusResource\Pages;
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -21,6 +22,7 @@ class ListInteractionStatuses extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
                 TextColumn::make('color')

--- a/app-modules/interaction/src/Filament/Resources/InteractionTypeResource/Pages/ListInteractionTypes.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionTypeResource/Pages/ListInteractionTypes.php
@@ -4,6 +4,7 @@ namespace Assist\Interaction\Filament\Resources\InteractionTypeResource\Pages;
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -20,6 +21,7 @@ class ListInteractionTypes extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->searchable(),
             ])

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/ListKnowledgeBaseCategories.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/ListKnowledgeBaseCategories.php
@@ -4,6 +4,7 @@ namespace Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource\
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -20,9 +21,7 @@ class ListKnowledgeBaseCategories extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/ViewKnowledgeBaseCategory.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/ViewKnowledgeBaseCategory.php
@@ -19,9 +19,6 @@ class ViewKnowledgeBaseCategory extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
@@ -3,6 +3,7 @@
 namespace Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseItemResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
@@ -22,6 +23,7 @@ class ListKnowledgeBaseItems extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('question')
                     ->label('Question/Issue/Feature')
                     ->translateLabel()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ViewKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ViewKnowledgeBaseItem.php
@@ -20,9 +20,6 @@ class ViewKnowledgeBaseItem extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('question')
                             ->label('Question/Issue/Feature')
                             ->translateLabel(),

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseQualityResource/Pages/ListKnowledgeBaseQualities.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseQualityResource/Pages/ListKnowledgeBaseQualities.php
@@ -4,6 +4,7 @@ namespace Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseQualityResource\P
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -20,9 +21,7 @@ class ListKnowledgeBaseQualities extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseQualityResource/Pages/ViewKnowledgeBaseQuality.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseQualityResource/Pages/ViewKnowledgeBaseQuality.php
@@ -19,9 +19,6 @@ class ViewKnowledgeBaseQuality extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseStatusResource/Pages/ListKnowledgeBaseStatuses.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseStatusResource/Pages/ListKnowledgeBaseStatuses.php
@@ -4,6 +4,7 @@ namespace Assist\KnowledgeBase\Filament\Resources\KnowledgeBaseStatusResource\Pa
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -20,9 +21,7 @@ class ListKnowledgeBaseStatuses extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseStatusResource/Pages/ViewKnowledgeBaseStatus.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseStatusResource/Pages/ViewKnowledgeBaseStatus.php
@@ -19,9 +19,6 @@ class ViewKnowledgeBaseStatus extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -3,6 +3,7 @@
 namespace Assist\Prospect\Filament\Resources\ProspectResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Assist\Prospect\Models\Prospect;
 use App\Filament\Actions\ImportAction;
@@ -28,6 +29,7 @@ class ListProspects extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make(Prospect::displayNameKey())
                     ->label('Name')
                     ->searchable()

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
@@ -5,6 +5,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectResource\Pages;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Assist\Alert\Enums\AlertStatus;
 use Assist\Prospect\Models\Prospect;
 use Assist\Alert\Enums\AlertSeverity;
@@ -99,6 +100,7 @@ class ManageProspectAlerts extends ManageRelatedRecords
         return $table
             ->recordTitleAttribute('description')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('description')
                     ->limit(),
                 TextColumn::make('severity')

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectSubscriptions.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectSubscriptions.php
@@ -4,6 +4,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectResource\Pages;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use App\Filament\Resources\UserResource;
@@ -44,6 +45,7 @@ class ManageProspectSubscriptions extends ManageRelatedRecords
         return $table
             ->recordTitleAttribute('user.name')
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('user.name')
                     ->url(fn ($record) => UserResource::getUrl('view', ['record' => $record->user]))
                     ->color('primary'),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ViewProspect.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ViewProspect.php
@@ -24,9 +24,6 @@ class ViewProspect extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('status.name')
                             ->label('Status')
                             ->translateLabel(),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementFilesRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementFilesRelationManager.php
@@ -6,6 +6,7 @@ use Filament\Forms;
 use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -34,6 +35,7 @@ class EngagementFilesRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('description')
             ->columns([
+                IdColumn::make(),
                 Tables\Columns\TextColumn::make('description'),
                 SpatieMediaLibraryImageColumn::make('file')
                     ->collection('file')

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementResponsesRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementResponsesRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectResource\RelationManagers;
 
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Infolists\Components\TextEntry;
@@ -29,7 +30,7 @@ class EngagementResponsesRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('id')
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('content'),
                 TextColumn::make('sent_at')
                     ->dateTime('Y-m-d H:i:s'),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
@@ -5,6 +5,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectResource\RelationManagers;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
+use App\Filament\Columns\IdColumn;
 use Assist\Prospect\Models\Prospect;
 use Filament\Forms\Components\Hidden;
 use Filament\Tables\Actions\ViewAction;
@@ -84,7 +85,7 @@ class EngagementsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('id')
             ->columns([
-                TextColumn::make('id'),
+                IdColumn::make(),
                 TextColumn::make('subject'),
                 TextColumn::make('body'),
                 TextColumn::make('channels')

--- a/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/ListProspectSources.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/ListProspectSources.php
@@ -4,6 +4,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectSourceResource\Pages;
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -20,9 +21,7 @@ class ListProspectSources extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/ViewProspectSource.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/ViewProspectSource.php
@@ -19,9 +19,6 @@ class ViewProspectSource extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ListProspectStatuses.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ListProspectStatuses.php
@@ -4,6 +4,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectStatusResource\Pages;
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -21,9 +22,7 @@ class ListProspectStatuses extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
@@ -20,9 +20,6 @@ class ViewProspectStatus extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/prospect/tests/ProspectSource/ViewProspectSourceTest.php
+++ b/app-modules/prospect/tests/ProspectSource/ViewProspectSourceTest.php
@@ -20,8 +20,6 @@ test('The correct details are displayed on the ViewProspectSource page', functio
         ->assertSuccessful()
         ->assertSeeTextInOrder(
             [
-                'ID',
-                $prospectSource->id,
                 'Name',
                 $prospectSource->name,
             ]

--- a/app-modules/prospect/tests/ProspectStatus/ViewProspectStatusTest.php
+++ b/app-modules/prospect/tests/ProspectStatus/ViewProspectStatusTest.php
@@ -20,8 +20,6 @@ test('The correct details are displayed on the ViewProspectStatus page', functio
         ->assertSuccessful()
         ->assertSeeTextInOrder(
             [
-                'ID',
-                $prospectStatus->id,
                 'Name',
                 $prospectStatus->name,
                 'Color',

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestPriorityResource/Pages/ListServiceRequestPriorities.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestPriorityResource/Pages/ListServiceRequestPriorities.php
@@ -4,6 +4,7 @@ namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestPriorityReso
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -20,6 +21,7 @@ class ListServiceRequestPriorities extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/EditServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/EditServiceRequest.php
@@ -8,7 +8,6 @@ use App\Models\Institution;
 use Assist\Prospect\Models\Prospect;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Builder;
 use Assist\AssistDataModel\Models\Student;
@@ -25,8 +24,6 @@ class EditServiceRequest extends EditRecord
     public function form(Form $form): Form
     {
         return parent::form($form)->schema([
-            TextInput::make('id')
-                ->disabled(),
             Select::make('institution_id')
                 ->relationship('institution', 'name')
                 ->label('Institution')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -4,6 +4,7 @@ namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pag
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -24,6 +25,7 @@ class ListServiceRequests extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('service_request_number')
                     ->label('Service Request #')
                     ->searchable()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
@@ -24,9 +24,6 @@ class ViewServiceRequest extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('service_request_number')
                             ->label('Service Request Number')
                             ->translateLabel(),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use App\Filament\Resources\UserResource;
 use Assist\ServiceManagement\Models\ServiceRequest;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -31,6 +32,7 @@ class AssignedToRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 Tables\Columns\TextColumn::make('name')
                     ->label('Name'),
             ])

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/CreatedByRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/CreatedByRelationManager.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use App\Filament\Resources\UserResource;
 use App\Filament\Resources\RelationManagers\RelationManager;
 
@@ -30,6 +31,7 @@ class CreatedByRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 Tables\Columns\TextColumn::make('name')
                     ->label('Name'),
             ])

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -6,6 +6,7 @@ use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
+use App\Filament\Columns\IdColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Textarea;
@@ -47,6 +48,7 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('update')
                     ->label('Update')
                     ->translateLabel()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/ListServiceRequestStatuses.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/ListServiceRequestStatuses.php
@@ -4,6 +4,7 @@ namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestStatusResour
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -21,9 +22,7 @@ class ListServiceRequestStatuses extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/ViewServiceRequestStatus.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/ViewServiceRequestStatus.php
@@ -20,9 +20,6 @@ class ViewServiceRequestStatus extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ListServiceRequestTypes.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ListServiceRequestTypes.php
@@ -4,6 +4,7 @@ namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestTypeResource
 
 use Filament\Actions;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -22,9 +23,7 @@ class ListServiceRequestTypes extends ListRecords
     {
         return parent::table($table)
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 TextColumn::make('name')
                     ->label('Name')
                     ->searchable()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ViewServiceRequestType.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ViewServiceRequestType.php
@@ -19,9 +19,6 @@ class ViewServiceRequestType extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('name')
                             ->label('Name')
                             ->translateLabel(),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
 use Filament\Resources\Resource;
+use App\Filament\Columns\IdColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Textarea;
@@ -62,9 +63,7 @@ class ServiceRequestUpdateResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
+                IdColumn::make(),
                 Tables\Columns\TextColumn::make('serviceRequest.respondent.full')
                     ->label('Respondent')
                     ->sortable(query: function (Builder $query, string $direction, $record): Builder {

--- a/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
@@ -20,8 +20,6 @@ test('The correct details are displayed on the ViewServiceRequest page', functio
         ->assertSuccessful()
         ->assertSeeTextInOrder(
             [
-                'ID',
-                $serviceRequest->id,
                 'Service Request Number',
                 $serviceRequest->service_request_number,
                 'Institution',

--- a/app-modules/service-management/tests/ServiceRequestStatus/ViewServiceRequestStatusTest.php
+++ b/app-modules/service-management/tests/ServiceRequestStatus/ViewServiceRequestStatusTest.php
@@ -20,8 +20,6 @@ test('The correct details are displayed on the ViewServiceRequestStatus page', f
         ->assertSuccessful()
         ->assertSeeTextInOrder(
             [
-                'ID',
-                $serviceRequestStatus->id,
                 'Name',
                 $serviceRequestStatus->name,
                 'Color',

--- a/app-modules/service-management/tests/ServiceRequestType/ViewServiceRequestTypeTest.php
+++ b/app-modules/service-management/tests/ServiceRequestType/ViewServiceRequestTypeTest.php
@@ -20,8 +20,6 @@ test('The correct details are displayed on the ViewServiceRequestType page', fun
         ->assertSuccessful()
         ->assertSeeTextInOrder(
             [
-                'ID',
-                $serviceRequestType->id,
                 'Name',
                 $serviceRequestType->name,
             ]

--- a/app-modules/task/src/Filament/Pages/Components/TaskKanbanViewAction.php
+++ b/app-modules/task/src/Filament/Pages/Components/TaskKanbanViewAction.php
@@ -16,20 +16,17 @@ class TaskKanbanViewAction extends ViewAction
     {
         parent::setUp();
 
-        $this->extraModalFooterActions(
-            [
-                Action::make('mark_as_in_progress')
-                    ->label('Mark as In Progress')
-                    ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::IN_PROGRESS))
-                    ->cancelParentActions()
-                    ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::IN_PROGRESS->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
-                Action::make('mark_as_completed')
-                    ->label('Mark as Completed')
-                    ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::COMPLETED))
-                    ->cancelParentActions()
-                    ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::COMPLETED->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
-            ]
-        )
-            ->infolist($this->taskInfoList());
+        $this->extraModalFooterActions([
+            Action::make('mark_as_in_progress')
+                ->label('Mark as In Progress')
+                ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::IN_PROGRESS))
+                ->cancelParentActions()
+                ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::IN_PROGRESS->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
+            Action::make('mark_as_completed')
+                ->label('Mark as Completed')
+                ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::COMPLETED))
+                ->cancelParentActions()
+                ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::COMPLETED->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
+        ])->infolist($this->taskInfoList());
     }
 }

--- a/app-modules/task/src/Filament/Resources/TaskResource/Components/TaskViewAction.php
+++ b/app-modules/task/src/Filament/Resources/TaskResource/Components/TaskViewAction.php
@@ -16,20 +16,17 @@ class TaskViewAction extends ViewAction
     {
         parent::setUp();
 
-        $this->extraModalFooterActions(
-            [
-                Action::make('mark_as_in_progress')
-                    ->label('Mark as In Progress')
-                    ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::IN_PROGRESS))
-                    ->cancelParentActions()
-                    ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::IN_PROGRESS->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
-                Action::make('mark_as_completed')
-                    ->label('Mark as Completed')
-                    ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::COMPLETED))
-                    ->cancelParentActions()
-                    ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::COMPLETED->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
-            ]
-        )
-            ->infolist($this->taskInfoList());
+        $this->extraModalFooterActions([
+            Action::make('mark_as_in_progress')
+                ->label('Mark as In Progress')
+                ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::IN_PROGRESS))
+                ->cancelParentActions()
+                ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::IN_PROGRESS->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
+            Action::make('mark_as_completed')
+                ->label('Mark as Completed')
+                ->action(fn (Task $record) => $record->getStateMachine('status')->transitionTo(TaskStatus::COMPLETED))
+                ->cancelParentActions()
+                ->hidden(fn (Task $record) => $record->getStateMachine('status')->getStateTransitions()->doesntContain(TaskStatus::COMPLETED->value) || auth()?->user()?->cannot("task.{$record->id}.update")),
+        ])->infolist($this->taskInfoList());
     }
 }

--- a/app-modules/task/src/Filament/Resources/TaskResource/Pages/ListTasks.php
+++ b/app-modules/task/src/Filament/Resources/TaskResource/Pages/ListTasks.php
@@ -7,6 +7,7 @@ use Filament\Forms\Set;
 use Filament\Tables\Table;
 use Assist\Task\Models\Task;
 use Assist\Task\Enums\TaskStatus;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Filters\Filter;
 use Assist\Prospect\Models\Prospect;
@@ -40,6 +41,7 @@ class ListTasks extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('title')
                     ->searchable()
                     ->wrap()

--- a/app-modules/team/src/Filament/Resources/TeamResource/Pages/ListTeams.php
+++ b/app-modules/team/src/Filament/Resources/TeamResource/Pages/ListTeams.php
@@ -3,6 +3,7 @@
 namespace Assist\Team\Filament\Resources\TeamResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
@@ -21,6 +22,7 @@ class ListTeams extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('description')
                     ->limit(50),

--- a/app-modules/team/src/Filament/Resources/TeamResource/RelationManagers/UsersRelationManager.php
+++ b/app-modules/team/src/Filament/Resources/TeamResource/RelationManagers/UsersRelationManager.php
@@ -6,6 +6,7 @@ use Closure;
 use App\Models\User;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Actions\AttachAction;
@@ -32,6 +33,7 @@ class UsersRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('email'),
             ])

--- a/app-modules/webhook/src/Filament/Resources/InboundWebhookResource/Pages/ListInboundWebhooks.php
+++ b/app-modules/webhook/src/Filament/Resources/InboundWebhookResource/Pages/ListInboundWebhooks.php
@@ -3,6 +3,7 @@
 namespace Assist\Webhook\Filament\Resources\InboundWebhookResource\Pages;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Resources\Pages\ListRecords;
@@ -16,6 +17,7 @@ class ListInboundWebhooks extends ListRecords
     {
         return parent::table($table)
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('source')
                     ->label('Source'),
                 TextColumn::make('event'),

--- a/app-modules/webhook/src/Filament/Resources/InboundWebhookResource/Pages/ViewInboundWebhook.php
+++ b/app-modules/webhook/src/Filament/Resources/InboundWebhookResource/Pages/ViewInboundWebhook.php
@@ -18,9 +18,6 @@ class ViewInboundWebhook extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('id')
-                            ->label('ID')
-                            ->translateLabel(),
                         TextEntry::make('source')
                             ->translateLabel(),
                         TextEntry::make('event')

--- a/app/Filament/Columns/IdColumn.php
+++ b/app/Filament/Columns/IdColumn.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Columns;
+
+use Filament\Tables\Columns\TextColumn;
+
+class IdColumn extends TextColumn
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('ID');
+
+        $this->sortable();
+
+        $this->toggleable(isToggledHiddenByDefault: true);
+    }
+
+    public static function make(string $name = 'id'): static
+    {
+        return parent::make($name);
+    }
+}

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Filament\Resources\Resource;
+use App\Filament\Columns\IdColumn;
 use Filament\Forms\Components\Toggle;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
@@ -53,6 +54,7 @@ class UserResource extends Resource
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('email')
                     ->label('Email address'),

--- a/app/Filament/Resources/UserResource/RelationManagers/PermissionsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/PermissionsRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\UserResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -31,6 +32,7 @@ class PermissionsRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('guard_name'),
             ])

--- a/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\UserResource\RelationManagers;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Actions\AttachAction;
@@ -35,6 +36,7 @@ class RoleGroupsRelationManager extends RelationManager implements HasActions
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
             ])
             ->filters([

--- a/app/Filament/Resources/UserResource/RelationManagers/RolesRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/RolesRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\UserResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Forms\Components\TextInput;
 use App\Filament\Resources\RelationManagers\RelationManager;
@@ -31,6 +32,7 @@ class RolesRelationManager extends RelationManager
     {
         return $table
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('name'),
                 TextColumn::make('guard_name'),
                 TextColumn::make('pivot.via')->label('Via'),

--- a/app/Filament/Widgets/MyServiceRequests.php
+++ b/app/Filament/Widgets/MyServiceRequests.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
@@ -32,6 +33,7 @@ class MyServiceRequests extends BaseWidget
                     ->limit(5)
             )
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('service_request_number')
                     ->label('Service Request #')
                     ->searchable()

--- a/app/Filament/Widgets/MyTasks.php
+++ b/app/Filament/Widgets/MyTasks.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use Filament\Tables\Table;
 use Assist\Task\Models\Task;
 use Assist\Task\Enums\TaskStatus;
+use App\Filament\Columns\IdColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Widgets\TableWidget as BaseWidget;
@@ -29,6 +30,7 @@ class MyTasks extends BaseWidget
                     ->byNextDue()
             )
             ->columns([
+                IdColumn::make(),
                 TextColumn::make('description')
                     ->searchable()
                     ->wrap()

--- a/app/Filament/Widgets/RecentLeadsList.php
+++ b/app/Filament/Widgets/RecentLeadsList.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use Filament\Tables\Table;
+use App\Filament\Columns\IdColumn;
 use Assist\Prospect\Models\Prospect;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -34,8 +35,7 @@ class RecentLeadsList extends BaseWidget
                 Prospect::latest()->limit(10)
             )
             ->columns([
-                TextColumn::make('id')
-                    ->hidden(),
+                IdColumn::make(),
                 TextColumn::make(Prospect::displayNameKey())
                     ->label('Name'),
                 TextColumn::make('email')


### PR DESCRIPTION
https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/535/
https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/545/

As per our discussion I replaced all the existing Id table columns with a new custom default hidden toggleable IdColumn, and added it for most models. I also removed the Id field from all infolists and forms.