### PR TITLE
[ASSIST-361]: Add PR templates to GitHub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Before contributing and submitting this PR, make sure you have:
+* [ ] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
+* [ ] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
+* [ ] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
+* [ ] Resolved all conflicts, if any.
+* [ ] Rebased your branch PR on top of the latest upstream `develop` branch.
+* [ ] Removed this checklist from the PR description.
+_______________________________________________

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,35 @@
+### Ticket(s) or GitHub Issue
+
+- [LINK_TO_TICKET] OR [LINK_TO_GITHUB_ISSUE]
+
+### Technical Description
+
+Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
+
+### Types of changes
+
+What types of changes does your code introduce? Put an `x` in all the boxes that apply:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Content or styling update (Changes which don't affect functionality)
+- [ ] DevOps
+- [ ] Documentation
+
+### Screenshots (if appropriate)
+
+### Any deployment steps required?
+
+A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
+
+- [ ] Yes, please specify
+- [ ] No
+
+_______________________________________________
+
 ## Before contributing and submitting this PR, make sure you have:
 * [ ] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
 * [ ] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
 * [ ] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
 * [ ] Resolved all conflicts, if any.
 * [ ] Rebased your branch PR on top of the latest upstream `develop` branch.
-* [ ] Removed this checklist from the PR description.
-_______________________________________________


### PR DESCRIPTION
https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/361/

This adds the first version of a PR template for this repository. I can evolve over time as the project grows, but this should paint a clear picture of what we are already doing here.

@danharrin, @dgoetzit, @mxm1070, and @joelicatajr I think it would be best for everyone to review and approve if they are happy with this first pass.