### PR TITLE
[ASSIST-603] Ensure Message Center is static height

### DIFF
--- a/app-modules/engagement/database/factories/EngagementDeliverableFactory.php
+++ b/app-modules/engagement/database/factories/EngagementDeliverableFactory.php
@@ -63,6 +63,8 @@ class EngagementDeliverableFactory extends Factory
         ]);
     }
 
+    // TODO Potentially think about extracting this concept as a trait
+    // And adding the ability to "weight" certain states more than others
     public function randomizeState(): self
     {
         $states = ['deliveryAwaiting', 'deliverySuccessful', 'deliveryFailed'];

--- a/app-modules/engagement/resources/views/components/filters.blade.php
+++ b/app-modules/engagement/resources/views/components/filters.blade.php
@@ -15,16 +15,10 @@
     <div class="flex w-full flex-col space-y-2">
         <span>Date Range</span>
 
-        <div class="flex w-full flex-col items-center">
-            <div class="relative w-full">
-                <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                    <x-filament::icon
-                        class="h-4 w-4 text-gray-500 dark:text-gray-400"
-                        icon="heroicon-o-calendar-days"
-                    />
-                </div>
+        <div class="flex w-full flex-col items-center space-y-2">
+            <div class="w-full">
                 <input
-                    class="block w-full rounded-lg border border-gray-300 bg-white p-2.5 pl-10 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    class="block w-full rounded-lg border border-gray-300 bg-white p-2.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                     name="filterStartDate"
                     type="date"
                     wire:model.live="filterStartDate"
@@ -32,15 +26,9 @@
                 >
             </div>
             <span class="mx-4 text-gray-500">to</span>
-            <div class="relative w-full">
-                <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                    <x-filament::icon
-                        class="h-4 w-4 text-gray-500 dark:text-gray-400"
-                        icon="heroicon-o-calendar-days"
-                    />
-                </div>
+            <div class="w-full">
                 <input
-                    class="block w-full rounded-lg border border-gray-300 bg-transparent p-2.5 pl-10 text-sm text-gray-900 dark:border-gray-600 dark:text-white"
+                    class="block w-full rounded-lg border border-gray-300 bg-transparent p-2.5 text-sm text-gray-900 dark:border-gray-600 dark:text-white"
                     name="filterEndDate"
                     type="date"
                     wire:model.live="filterEndDate"
@@ -72,11 +60,3 @@
         </span>
     </label>
 </div>
-
-<style>
-    input[type="date"]::-webkit-inner-spin-button,
-    input[type="date"]::-webkit-calendar-picker-indicator {
-        display: none;
-        -webkit-appearance: none;
-    }
-</style>

--- a/app-modules/engagement/resources/views/components/message-center-content.blade.php
+++ b/app-modules/engagement/resources/views/components/message-center-content.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="mt-2 w-full overflow-y-scroll rounded-l-lg rounded-r-lg bg-white dark:border-gray-700 dark:bg-gray-900 md:mt-0 md:max-h-content md:rounded-l-none md:border-l">
+    class="col-span-full mt-2 h-full overflow-y-auto rounded-l-lg rounded-r-lg bg-white dark:border-gray-700 dark:bg-gray-900 md:col-span-3 md:mt-0 md:rounded-l-none md:border-l">
     @if ($loadingTimeline)
         <x-filament::loading-indicator class="h-12 w-12" />
     @else
@@ -8,7 +8,7 @@
                 <x-engagement::empty-state />
             </div>
         @else
-            <div>
+            <div class="max-h-full overflow-y-auto">
                 <div
                     class="sticky top-0 z-[5] flex h-12 w-full items-center justify-between bg-gray-100 px-4 dark:bg-gray-700">
                     <h1 class="ml-2">{{ $educatable->display_name }}</h1>

--- a/app-modules/engagement/resources/views/components/message-center-inbox.blade.php
+++ b/app-modules/engagement/resources/views/components/message-center-inbox.blade.php
@@ -3,28 +3,30 @@
 @endphp
 
 <div
-    class="max-h-content w-full overflow-y-scroll rounded-bl-lg rounded-br-lg rounded-tl-lg rounded-tr-lg bg-white dark:bg-gray-800 sm:rounded-br-none sm:rounded-tr-none lg:w-1/3"
+    class="col-span-full h-full overflow-y-auto rounded-bl-lg rounded-br-lg rounded-tl-lg rounded-tr-lg bg-white dark:bg-gray-800 sm:rounded-br-none sm:rounded-tr-none md:col-span-1"
     x-data="{ showFilters: false }"
 >
-    <div class="flex items-center justify-between rounded-tl-lg bg-white p-4 dark:bg-gray-800">
-        <div class="flex flex-col">
-            <span class="font-bold text-gray-500 dark:text-gray-400 sm:text-xs md:text-sm">
-                Engagements
-            </span>
-            <span class="text-xs text-gray-400 dark:text-gray-500">
-                {{ $educatables->total() }} Total Results
-            </span>
+    <div class="sticky top-0 z-[5] flex flex-col rounded-tl-lg bg-white dark:bg-gray-800">
+        <div class="flex flex-row items-center justify-between p-4">
+            <div class="flex flex-col">
+                <span class="font-bold text-gray-500 dark:text-gray-400 sm:text-xs md:text-sm">
+                    Engagements
+                </span>
+                <span class="text-xs text-gray-400 dark:text-gray-500">
+                    {{ $educatables->total() }} Total Results
+                </span>
+            </div>
+            <x-filament::icon-button
+                icon="heroicon-m-funnel"
+                x-on:click="showFilters = !showFilters"
+                label="Show Filters and Search"
+            />
         </div>
-        <x-filament::icon-button
-            icon="heroicon-m-funnel"
-            x-on:click="showFilters = !showFilters"
-            label="Show Filters and Search"
-        />
+
+        <x-engagement::filters />
+
+        <x-engagement::search />
     </div>
-
-    <x-engagement::filters />
-
-    <x-engagement::search />
 
     <div class="hidden flex-col md:flex">
         <div class="overflow-x-auto">

--- a/app-modules/engagement/resources/views/components/pagination.blade.php
+++ b/app-modules/engagement/resources/views/components/pagination.blade.php
@@ -67,6 +67,7 @@
 
                             {{-- Array Of Links --}}
                             @if (is_array($element))
+                                {{-- TODO Don't show all links --}}
                                 @foreach ($element as $page => $url)
                                     <span wire:key="paginator-{{ $paginator->getPageName() }}-page{{ $page }}">
                                         @if ($page == $paginator->currentPage())

--- a/app-modules/engagement/resources/views/filament/pages/message-center.blade.php
+++ b/app-modules/engagement/resources/views/filament/pages/message-center.blade.php
@@ -1,19 +1,25 @@
-<x-filament::page>
+<x-filament-panels::page
+    class="flex h-full flex-col"
+    style="max-height: calc(100vh - 8rem)"
+    full-height="true"
+>
     <div
-        class="flex max-h-full w-full flex-col rounded-lg border-0 border-gray-200 dark:border-gray-700 md:flex-row md:border">
-        @if ($loadingInbox)
-            <x-filament::loading-indicator class="h-12 w-12" />
-        @else
-            <x-engagement::message-center-inbox
-                :selectedEducatable="$selectedEducatable"
-                :educatables="$educatables"
-            />
+        class="h-full w-full flex-1 flex-col rounded-lg border-0 border-gray-200 dark:border-gray-700 md:overflow-y-auto md:border">
+        <div class="grid h-full grid-cols-1 md:grid-cols-4">
+            @if ($loadingInbox)
+                <x-filament::loading-indicator class="col-span-full h-12 w-12" />
+            @else
+                <x-engagement::message-center-inbox
+                    :selectedEducatable="$selectedEducatable"
+                    :educatables="$educatables"
+                />
 
-            <x-engagement::message-center-content
-                :loadingTimeline="$loadingTimeline"
-                :educatable="$selectedEducatable"
-                :aggregateRecords="$aggregateRecordsForEducatable"
-            />
-        @endif
+                <x-engagement::message-center-content
+                    :loadingTimeline="$loadingTimeline"
+                    :educatable="$selectedEducatable"
+                    :aggregateRecords="$aggregateRecordsForEducatable"
+                />
+            @endif
+        </div>
     </div>
-</x-filament::page>
+</x-filament-panels::page>

--- a/app-modules/engagement/src/Filament/Concerns/EngagementInfolist.php
+++ b/app-modules/engagement/src/Filament/Concerns/EngagementInfolist.php
@@ -33,7 +33,7 @@ trait EngagementInfolist
                         })
                         ->color(fn (EngagementDeliveryStatus $state): string => match ($state) {
                             EngagementDeliveryStatus::Successful => 'success',
-                            EngagementDeliveryStatus::Awaiting => 'info',
+                            EngagementDeliveryStatus::Awaiting => 'warning',
                             EngagementDeliveryStatus::Failed => 'danger',
                         }),
                     TextEntry::make('delivered_at'),


### PR DESCRIPTION
This PR makes sure that the Message Center content is static and overflows with a scroll when appropriate. Also fixes an issue with the html datepicker, cohesiveness in design styles.