### PR TITLE
[ASSIST-557] Enhance AI consent configuration update behavior

### DIFF
--- a/app-modules/consent/src/Enums/ConsentAgreementType.php
+++ b/app-modules/consent/src/Enums/ConsentAgreementType.php
@@ -5,4 +5,12 @@ namespace Assist\Consent\Enums;
 enum ConsentAgreementType: string
 {
     case AzureOpenAI = 'azure_open_ai';
+
+    // We may end up moving this to the model itself, but for now it doesn't quite make sense to make this editable by an admin
+    public function getModalDescription(): string
+    {
+        return match ($this) {
+            self::AzureOpenAI => "Warning: Changing the AI Consent Configuration will reset everyone's consents, making them agree to your new terms all over again. There's no undoing this, so please make sure this is your intention.",
+        };
+    }
 }

--- a/app-modules/consent/src/Filament/Resources/ConsentAgreementResource/Pages/EditConsentAgreement.php
+++ b/app-modules/consent/src/Filament/Resources/ConsentAgreementResource/Pages/EditConsentAgreement.php
@@ -3,15 +3,22 @@
 namespace Assist\Consent\Filament\Resources\ConsentAgreementResource\Pages;
 
 use Filament\Forms\Form;
+use Filament\Actions\Action;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Support\Htmlable;
 use Assist\Consent\Filament\Resources\ConsentAgreementResource;
 
 class EditConsentAgreement extends EditRecord
 {
     protected static string $resource = ConsentAgreementResource::class;
+
+    public function getTitle(): string | Htmlable
+    {
+        return "Edit {$this->record->title}";
+    }
 
     public function form(Form $form): Form
     {
@@ -35,8 +42,24 @@ class EditConsentAgreement extends EditRecord
             ]);
     }
 
-    protected function getHeaderActions(): array
+    protected function getFormActions(): array
     {
-        return [];
+        return [
+            Action::make('Save Changes')
+                ->requiresConfirmation()
+                ->modalIconColor('warning')
+                ->modalHeading("Save Changes to {$this->record->title}?")
+                ->modalDescription($this->record->type->getModalDescription())
+                ->modalSubmitActionLabel('I understand, save changes')
+                ->modalWidth('xl')
+                ->action(function () {
+                    $this->save();
+
+                    if ($this->record->users->count() > 0) {
+                        $this->record->users()->detach();
+                    }
+                }),
+            $this->getCancelFormAction(),
+        ];
     }
 }

--- a/app-modules/consent/src/Models/ConsentAgreement.php
+++ b/app-modules/consent/src/Models/ConsentAgreement.php
@@ -4,14 +4,18 @@ namespace Assist\Consent\Models;
 
 use App\Models\User;
 use App\Models\BaseModel;
+use OwenIt\Auditing\Contracts\Auditable;
 use Assist\Audit\Overrides\BelongsToMany;
 use Assist\Consent\Enums\ConsentAgreementType;
+use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
 
 /**
  * @mixin IdeHelperConsentAgreement
  */
-class ConsentAgreement extends BaseModel
+class ConsentAgreement extends BaseModel implements Auditable
 {
+    use AuditableTrait;
+
     protected $casts = [
         'type' => ConsentAgreementType::class,
     ];
@@ -22,7 +26,7 @@ class ConsentAgreement extends BaseModel
         'body',
     ];
 
-    public function user(): BelongsToMany
+    public function users(): BelongsToMany
     {
         return $this->belongsToMany(User::class)
             ->withPivot('ip_address')

--- a/database/seeders/DemoDatabaseSeeder.php
+++ b/database/seeders/DemoDatabaseSeeder.php
@@ -48,6 +48,7 @@ class DemoDatabaseSeeder extends Seeder
             KnowledgeBaseItemSeeder::class,
             ...InteractionSeeder::metadataSeeders(),
             ConsentAgreementSeeder::class,
+            SuperAdminSeeder::class,
         ]);
     }
 }


### PR DESCRIPTION
This PR introduces new behavior for the AI Consent Configuration that will remove all previous user consent for a particular agreement on an update to an agreement. This is a precursor to versioning these agreements, which will come at a later point in time.

At this point in time, I have not implemented soft deletes on the pivot, as this would require some fundamental changes to the relationships/tables involved, and would likely be reverted back when we get to versioning these agreements. I have opened a discussion with product around this and will update this description as needed. For now, historical agreements and removals are just available in the audit trail.