### PR TITLE
[ASSIST-617]: Set background color on login

### DIFF
--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -24,6 +24,11 @@
 }
 
 /* Style Overrides */
+.fi-simple-layout {
+    @apply bg-trout-700;
+}
+
+
 /* .fi-sidebar-item {
     @apply text-assist-black-950 dark:text-assist-white-50  !important;
 }

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -28,7 +28,6 @@
     @apply bg-trout-700;
 }
 
-
 /* .fi-sidebar-item {
     @apply text-assist-black-950 dark:text-assist-white-50  !important;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,19 @@ export default {
         },
         // Changes to colors also need to be reflected in FilamentServiceProvider
         colors: {
+            trout: {
+                50: '#f6f7f9',
+                100: '#ededf1',
+                200: '#d7d9e0',
+                300: '#b4b9c5',
+                400: '#8b92a5',
+                500: '#6d758a',
+                600: '#575d72',
+                700: '#4d5264',
+                800: '#3e424e',
+                900: '#363944',
+                950: '#24252d',
+            },
             black: {
                 50: '#f6f6f6',
                 100: '#e7e7e7',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/617/

### Technical Description

This PR sets the background color on the login screen for light mode to `trout-700`.

### Types of changes

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

<img width="1915" alt="Screenshot 2023-10-11 at 4 19 19 PM" src="https://github.com/canyongbs/assistbycanyongbs/assets/10821263/cb3eb794-fd84-41b0-a10a-f9e15ef58487">

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.