### PR TITLE
[ASSIST-645]: Fix dark mode login background color 

### DIFF
--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -25,7 +25,7 @@
 
 /* Style Overrides */
 .fi-simple-layout {
-    @apply bg-trout-700;
+    @apply bg-trout-700 dark:bg-gray-950;
 }
 
 /* .fi-sidebar-item {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/645/

### Technical Description

This PR fixes the background color on the login page in dark mode.

### Types of changes

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

<img width="1329" alt="Screenshot 2023-10-13 at 8 21 02 AM" src="https://github.com/canyongbs/assistbycanyongbs/assets/10821263/bf1723ed-2ead-4ede-8489-a708c6bf021d">

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.