### PR TITLE
[ASSIST-653]: Bug: Adjust display of Role Group to Profile in RBAC interface. 

### DIFF
--- a/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
@@ -18,6 +18,10 @@ class RoleGroupsRelationManager extends RelationManager implements HasActions
 {
     use InteractsWithActions;
 
+    protected static ?string $label = 'Profile';
+
+    protected static ?string $title = 'Profiles';
+
     protected static string $relationship = 'roleGroups';
 
     protected static ?string $recordTitleAttribute = 'name';

--- a/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
@@ -53,11 +53,11 @@ class RoleGroupsRelationManager extends RelationManager implements HasActions
             ->actions([
                 DetachAction::make()
                     ->label(function ($record) {
-                        return "Remove from {$record->name} Role Group";
+                        return "Remove from {$record->name} Profile";
                     })
                     ->requiresConfirmation()
                     ->modalDescription(function ($record) {
-                        return "Are you sure you want to remove {$this->ownerRecord->name} from the {$record->name} Role Group?";
+                        return "Are you sure you want to remove {$this->ownerRecord->name} from the {$record->name} Profile?";
                     }),
             ])
             ->bulkActions([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/653/

### Technical Description

Adjusts wording in Role Group Manager for User to display as Profile for Users.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.