### PR TITLE
[ASSIST-765]: Spike: Resolve issue with implicit uuid casting (30 Minutes)

### DIFF
--- a/app-modules/assist-data-model/database/migrations/2023_08_11_235451_create_implicit_varchar_as_uuid_cast.php
+++ b/app-modules/assist-data-model/database/migrations/2023_08_11_235451_create_implicit_varchar_as_uuid_cast.php
@@ -9,6 +9,6 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        DB::raw('CREATE CAST (VARCHAR AS uuid) WITH INOUT AS IMPLICIT');
+        DB::unprepared('CREATE CAST (VARCHAR AS uuid) WITH INOUT AS IMPLICIT');
     }
 };

--- a/app-modules/assist-data-model/database/migrations/2023_08_11_235451_create_implicit_varchar_as_uuid_cast.php
+++ b/app-modules/assist-data-model/database/migrations/2023_08_11_235451_create_implicit_varchar_as_uuid_cast.php
@@ -9,6 +9,8 @@ return new class () extends Migration {
      */
     public function up(): void
     {
+        DB::unprepared('DROP CAST IF EXISTS (VARCHAR AS uuid)');
+
         DB::unprepared('CREATE CAST (VARCHAR AS uuid) WITH INOUT AS IMPLICIT');
     }
 };

--- a/app-modules/prospect/database/migrations/2023_07_26_000003_create_prospects_table.php
+++ b/app-modules/prospect/database/migrations/2023_07_26_000003_create_prospects_table.php
@@ -9,8 +9,7 @@ class CreateProspectsTable extends Migration
     public function up(): void
     {
         Schema::create('prospects', function (Blueprint $table) {
-            //Changed from uuid to resolve postgres inner join casting issue
-            $table->string('id')->primary();
+            $table->uuid('id')->primary();
             $table->foreignUuid('status_id')->references('id')->on('prospect_statuses');
             $table->foreignUuid('source_id')->references('id')->on('prospect_sources');
             $table->string('first_name');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/765/

### Technical Description

Switches Prospects back to uuid for the primary key. I could not reproduce an issue with the filter even after switching prospects back to a UUID column.
The filter works, and I get back the results I would expect.

If y'all have any specific details so I can reproduce an error to debug, let me know.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.