### PR TITLE
[ASSIST-787]: Simplify Detach Operation in Users and Profiles

### DIFF
--- a/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/RolesRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/RolesRelationManager.php
@@ -54,9 +54,7 @@ class RolesRelationManager extends RelationManager
                 // TODO We'll want to modify the messages of the detach to make it more clear
                 // To the end user they are also removing all of the roles from the user
                 // That have been assigned to them through the RoleGroup
-                DetachAction::make()->label(function () {
-                    return 'Remove from ' . $this->ownerRecord->name . ' Role Group';
-                }),
+                DetachAction::make(),
             ])
             ->bulkActions([
                 BulkActionGroup::make([

--- a/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/UsersRelationManager.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleGroupResource/RelationManagers/UsersRelationManager.php
@@ -44,9 +44,7 @@ class UsersRelationManager extends RelationManager
                 // TODO We'll want to modify the messages of the detach to make it more clear
                 // To the end user they are also removing all of the roles from the user
                 // That have been assigned to them through the RoleGroup
-                DetachAction::make()->label(function () {
-                    return 'Remove from ' . $this->ownerRecord->name . ' Role Group';
-                }),
+                DetachAction::make(),
             ])
             ->bulkActions([
             ]);

--- a/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/RoleGroupsRelationManager.php
@@ -52,9 +52,6 @@ class RoleGroupsRelationManager extends RelationManager implements HasActions
             ])
             ->actions([
                 DetachAction::make()
-                    ->label(function ($record) {
-                        return "Remove from {$record->name} Profile";
-                    })
                     ->requiresConfirmation()
                     ->modalDescription(function ($record) {
                         return "Are you sure you want to remove {$this->ownerRecord->name} from the {$record->name} Profile?";


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/787/

### Technical Description

Changes the verbiage of the detach for Roles for both Profiles and Users -> Profiles.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.