### PR TITLE
[ASSIST-699]: Change the default status of Prospect Statuses from Dead to Not Available.

### DIFF
--- a/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
+++ b/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
@@ -40,8 +40,8 @@ class ProspectStatusSeeder extends Seeder
                         'color' => ProspectStatusColorOptions::Gray->value,
                     ],
                     [
-                        'classification' => SystemProspectClassification::Dead,
-                        'name' => 'Dead',
+                        'classification' => SystemProspectClassification::NotInterested,
+                        'name' => 'Not Interested',
                         'color' => ProspectStatusColorOptions::Danger->value,
                     ],
                 ]

--- a/app-modules/prospect/src/Enums/SystemProspectClassification.php
+++ b/app-modules/prospect/src/Enums/SystemProspectClassification.php
@@ -16,7 +16,7 @@ enum SystemProspectClassification: string implements HasLabel
 
     case Recycled = 'recycled';
 
-    case Dead = 'dead';
+    case NotInterested = 'not_interested';
 
     case Custom = 'custom';
 
@@ -24,6 +24,7 @@ enum SystemProspectClassification: string implements HasLabel
     {
         return match ($this) {
             SystemProspectClassification::InProgress => 'In Progress',
+            SystemProspectClassification::NotInterested => 'Not Interested',
             default => $this->name,
         };
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/699/

### Technical Description

Change the Prospect Status "Dead" status to be "Not Interested"

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.