### PR TITLE
[ASSIST-697]: Rename Pronouns on Product Settings to "User Profile Pronouns"

### DIFF
--- a/app/Filament/Resources/PronounsResource.php
+++ b/app/Filament/Resources/PronounsResource.php
@@ -18,6 +18,10 @@ class PronounsResource extends Resource
 
     protected static ?string $navigationGroup = 'Product Settings';
 
+    protected static ?string $label = 'User Profile Pronoun';
+
+    protected static ?string $pluralLabel = 'User Profile Pronouns';
+
     protected static ?int $navigationSort = 17;
 
     public static function form(Form $form): Form


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/697/

### Technical Description

Changes Pronouns menu item and page context to be User Profile Pronouns

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.