### PR TITLE
[ASSIST-721] Add a new campaign type for proactive alerts

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -167,6 +167,8 @@ namespace App\Models{
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Audit\Models\Audit> $audits
  * @property-read int|null $audits_count
  * @property-read \Assist\MeetingCenter\Models\Calendar|null $calendar
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\CareTeam\Models\CareTeam> $careTeams
+ * @property-read int|null $care_teams_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\CaseloadManagement\Models\Caseload> $caseloads
  * @property-read int|null $caseloads_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Consent\Models\ConsentAgreement> $consentAgreements
@@ -246,6 +248,7 @@ namespace Assist\Alert\Models{
 /**
  * Assist\Alert\Models\Alert
  *
+ * @property-read Student|Prospect $concern
  * @property string $id
  * @property string $concern_type
  * @property string $concern_id
@@ -258,7 +261,8 @@ namespace Assist\Alert\Models{
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Audit\Models\Audit> $audits
  * @property-read int|null $audits_count
- * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $concern
+ * @method static \Illuminate\Database\Eloquent\Builder|Alert educatableSearch(string $relationship, string $search)
+ * @method static \Illuminate\Database\Eloquent\Builder|Alert educatableSort(string $direction)
  * @method static \Assist\Alert\Database\Factories\AlertFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|Alert newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Alert newQuery()
@@ -747,6 +751,32 @@ namespace Assist\Campaign\Models{
  */
 	#[\AllowDynamicProperties]
  class IdeHelperCampaignAction {}
+}
+
+namespace Assist\CareTeam\Models{
+/**
+ * Assist\CareTeam\Models\CareTeam
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property string $educatable_id
+ * @property string $educatable_type
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $educatable
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam query()
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam whereEducatableId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam whereEducatableType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CareTeam whereUserId($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperCareTeam {}
 }
 
 namespace Assist\CaseloadManagement\Models{

--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -2,6 +2,7 @@
 
 namespace Assist\Alert\Models;
 
+use Exception;
 use App\Models\BaseModel;
 use Assist\Alert\Enums\AlertStatus;
 use Assist\Prospect\Models\Prospect;
@@ -9,11 +10,14 @@ use Assist\Alert\Enums\AlertSeverity;
 use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\Builder;
 use Assist\AssistDataModel\Models\Student;
+use Assist\Campaign\Models\CampaignAction;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Assist\AssistDataModel\Models\Contracts\Educatable;
 use Assist\Notifications\Models\Contracts\Subscribable;
 use Assist\AssistDataModel\Models\Traits\EducatableScopes;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
+use Assist\Campaign\Models\Contracts\ExecutableFromACampaignAction;
 use Assist\Notifications\Models\Contracts\CanTriggerAutoSubscription;
 
 /**
@@ -21,7 +25,7 @@ use Assist\Notifications\Models\Contracts\CanTriggerAutoSubscription;
  *
  * @mixin IdeHelperAlert
  */
-class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription
+class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, ExecutableFromACampaignAction
 {
     use SoftDeletes;
     use AuditableTrait;
@@ -54,5 +58,27 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription
     public function scopeStatus(Builder $query, AlertStatus $status)
     {
         $query->where('status', $status);
+    }
+
+    public static function executeFromCampaignAction(CampaignAction $action): bool|string
+    {
+        try {
+            $action->campaign->caseload->retrieveRecords()->each(function (Educatable $educatable) use ($action) {
+                Alert::create([
+                    'concern_type' => $educatable->getMorphClass(),
+                    'concern_id' => $educatable->getKey(),
+                    'description' => $action->data['description'],
+                    'severity' => $action->data['severity'],
+                    'status' => $action->data['status'],
+                    'suggested_intervention' => $action->data['suggested_intervention'],
+                ]);
+            });
+
+            return true;
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+
+        // Do we need to be able to relate campaigns/actions to the RESULT of their actions?
     }
 }

--- a/app-modules/campaign/src/Enums/CampaignActionType.php
+++ b/app-modules/campaign/src/Enums/CampaignActionType.php
@@ -10,11 +10,14 @@ enum CampaignActionType: string implements HasLabel
 
     case ServiceRequest = 'service_request';
 
+    case ProactiveAlert = 'proactive_alert';
+
     public function getLabel(): ?string
     {
         return match ($this) {
             CampaignActionType::BulkEngagement => 'Bulk Engagement',
             CampaignActionType::ServiceRequest => 'Service Request',
+            CampaignActionType::ProactiveAlert => 'Proactive Alert',
             default => $this->name,
         };
     }

--- a/app-modules/campaign/src/Enums/CampaignActionType.php
+++ b/app-modules/campaign/src/Enums/CampaignActionType.php
@@ -12,6 +12,8 @@ enum CampaignActionType: string implements HasLabel
 
     case ProactiveAlert = 'proactive_alert';
 
+    case Interaction = 'interaction';
+
     public function getLabel(): ?string
     {
         return match ($this) {

--- a/app-modules/campaign/src/Filament/Blocks/InteractionBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/InteractionBlock.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Assist\Campaign\Filament\Blocks;
+
+use Closure;
+use Assist\Division\Models\Division;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Fieldset;
+use Filament\Forms\Components\Textarea;
+use Illuminate\Database\Eloquent\Model;
+use Filament\Forms\Components\TextInput;
+use Assist\Interaction\Models\Interaction;
+use Filament\Forms\Components\DateTimePicker;
+use Assist\Interaction\Models\InteractionType;
+use Assist\Interaction\Models\InteractionDriver;
+use Assist\Interaction\Models\InteractionStatus;
+use Assist\Interaction\Models\InteractionOutcome;
+use Assist\Interaction\Models\InteractionCampaign;
+use Assist\Interaction\Models\InteractionRelation;
+
+class InteractionBlock extends CampaignActionBlock
+{
+    protected Model | string | Closure | null $model = Interaction::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Interaction');
+
+        $this->schema($this->createFields());
+    }
+
+    public function generateFields(string $fieldPrefix = ''): array
+    {
+        return [
+            Fieldset::make('Details')
+                ->schema([
+                    Select::make($fieldPrefix . 'interaction_campaign_id')
+                        ->relationship('campaign', 'name')
+                        ->label('Campaign')
+                        ->required()
+                        ->exists((new InteractionCampaign())->getTable(), 'id'),
+                    Select::make($fieldPrefix . 'interaction_driver_id')
+                        ->relationship('driver', 'name')
+                        ->preload()
+                        ->label('Driver')
+                        ->required()
+                        ->exists((new InteractionDriver())->getTable(), 'id'),
+                    Select::make($fieldPrefix . 'division_id')
+                        ->relationship('division', 'name')
+                        ->preload()
+                        ->label('Division')
+                        ->required()
+                        ->exists((new Division())->getTable(), 'id'),
+                    Select::make($fieldPrefix . 'interaction_outcome_id')
+                        ->relationship('outcome', 'name')
+                        ->preload()
+                        ->label('Outcome')
+                        ->required()
+                        ->exists((new InteractionOutcome())->getTable(), 'id'),
+                    Select::make($fieldPrefix . 'interaction_relation_id')
+                        ->relationship('relation', 'name')
+                        ->preload()
+                        ->label('Relation')
+                        ->required()
+                        ->exists((new InteractionRelation())->getTable(), 'id'),
+                    Select::make($fieldPrefix . 'interaction_status_id')
+                        ->relationship('status', 'name')
+                        ->preload()
+                        ->label('Status')
+                        ->required()
+                        ->exists((new InteractionStatus())->getTable(), 'id'),
+                    Select::make($fieldPrefix . 'interaction_type_id')
+                        ->relationship('type', 'name')
+                        ->preload()
+                        ->label('Type')
+                        ->required()
+                        ->exists((new InteractionType())->getTable(), 'id'),
+                ]),
+            Fieldset::make('Time')
+                ->schema([
+                    DateTimePicker::make($fieldPrefix . 'start_datetime')
+                        ->required(),
+                    DateTimePicker::make($fieldPrefix . 'end_datetime')
+                        ->required(),
+                ]),
+            Fieldset::make('Notes')
+                ->schema([
+                    TextInput::make($fieldPrefix . 'subject')
+                        ->required(),
+                    Textarea::make($fieldPrefix . 'description')
+                        ->required(),
+                ]),
+            DateTimePicker::make($fieldPrefix . 'execute_at')
+                ->label('When should the action be executed?')
+                ->required()
+                ->minDate(now(auth()->user()->timezone))
+                ->closeOnDateSelection(),
+        ];
+    }
+
+    public static function type(): string
+    {
+        return 'interaction';
+    }
+}

--- a/app-modules/campaign/src/Filament/Blocks/ProactiveAlertBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/ProactiveAlertBlock.php
@@ -14,7 +14,7 @@ class ProactiveAlertBlock extends CampaignActionBlock
     {
         parent::setUp();
 
-        $this->label('Proactive Alerts');
+        $this->label('Proactive Alert');
 
         $this->schema($this->createFields());
     }

--- a/app-modules/campaign/src/Filament/Blocks/ProactiveAlertBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/ProactiveAlertBlock.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Assist\Campaign\Filament\Blocks;
+
+use Assist\Alert\Enums\AlertStatus;
+use Assist\Alert\Enums\AlertSeverity;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\DateTimePicker;
+
+class ProactiveAlertBlock extends CampaignActionBlock
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Proactive Alerts');
+
+        $this->schema($this->createFields());
+    }
+
+    public function generateFields(string $fieldPrefix = ''): array
+    {
+        return [
+            Textarea::make($fieldPrefix . 'description')
+                ->required()
+                ->string(),
+            Select::make($fieldPrefix . 'severity')
+                ->options(AlertSeverity::class)
+                ->selectablePlaceholder(false)
+                ->default(AlertSeverity::default())
+                ->required()
+                ->enum(AlertSeverity::class),
+            Textarea::make($fieldPrefix . 'suggested_intervention')
+                ->required()
+                ->string(),
+            Select::make($fieldPrefix . 'status')
+                ->options(AlertStatus::class)
+                ->selectablePlaceholder(false)
+                ->default(AlertStatus::default())
+                ->required()
+                ->enum(AlertStatus::class),
+            DateTimePicker::make($fieldPrefix . 'execute_at')
+                ->label('When should the action be executed?')
+                ->required()
+                ->minDate(now(auth()->user()->timezone))
+                ->closeOnDateSelection(),
+        ];
+    }
+
+    public static function type(): string
+    {
+        return 'proactive_alert';
+    }
+}

--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\ViewField;
 use Filament\Forms\Components\Wizard\Step;
 use Filament\Resources\Pages\CreateRecord;
 use Assist\Campaign\Actions\CreateActionsForCampaign;
+use Assist\Campaign\Filament\Blocks\ProactiveAlertBlock;
 use Assist\Campaign\Filament\Blocks\ServiceRequestBlock;
 use Assist\Campaign\Filament\Resources\CampaignResource;
 use Assist\Campaign\Filament\Blocks\EngagementBatchBlock;
@@ -30,6 +31,7 @@ class CreateCampaign extends CreateRecord
         return [
             EngagementBatchBlock::make(),
             ServiceRequestBlock::make(),
+            ProactiveAlertBlock::make(),
         ];
     }
 

--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\ViewField;
 use Filament\Forms\Components\Wizard\Step;
 use Filament\Resources\Pages\CreateRecord;
 use Assist\Campaign\Actions\CreateActionsForCampaign;
+use Assist\Campaign\Filament\Blocks\InteractionBlock;
 use Assist\Campaign\Filament\Blocks\ProactiveAlertBlock;
 use Assist\Campaign\Filament\Blocks\ServiceRequestBlock;
 use Assist\Campaign\Filament\Resources\CampaignResource;
@@ -32,6 +33,7 @@ class CreateCampaign extends CreateRecord
             EngagementBatchBlock::make(),
             ServiceRequestBlock::make(),
             ProactiveAlertBlock::make(),
+            InteractionBlock::make(),
         ];
     }
 

--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/RelationManagers/CampaignActionsRelationManager.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/RelationManagers/CampaignActionsRelationManager.php
@@ -4,6 +4,7 @@ namespace Assist\Campaign\Filament\Resources\CampaignResource\RelationManagers;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Assist\Alert\Models\Alert;
 use Filament\Forms\Components\Builder;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
@@ -11,6 +12,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
 use Assist\Campaign\Models\CampaignAction;
+use Assist\Interaction\Models\Interaction;
 use Filament\Tables\Actions\BulkActionGroup;
 use Assist\Campaign\Enums\CampaignActionType;
 use Assist\Engagement\Models\EngagementBatch;
@@ -30,7 +32,9 @@ class CampaignActionsRelationManager extends RelationManager
 
         $form->model = match ($action->type) {
             CampaignActionType::BulkEngagement => EngagementBatch::class,
-            CampaignActionType::ServiceRequest => ServiceRequest::class
+            CampaignActionType::ServiceRequest => ServiceRequest::class,
+            CampaignActionType::ProactiveAlert => Alert::class,
+            CampaignActionType::Interaction => Interaction::class
         };
 
         return $form

--- a/app-modules/campaign/src/Models/CampaignAction.php
+++ b/app-modules/campaign/src/Models/CampaignAction.php
@@ -3,13 +3,17 @@
 namespace Assist\Campaign\Models;
 
 use App\Models\BaseModel;
+use Assist\Alert\Models\Alert;
 use OwenIt\Auditing\Contracts\Auditable;
+use Assist\Interaction\Models\Interaction;
 use Assist\Campaign\Enums\CampaignActionType;
 use Assist\Engagement\Models\EngagementBatch;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Assist\ServiceManagement\Models\ServiceRequest;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Assist\Campaign\Filament\Blocks\InteractionBlock;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Assist\Campaign\Filament\Blocks\ProactiveAlertBlock;
 use Assist\Campaign\Filament\Blocks\ServiceRequestBlock;
 use Assist\Campaign\Filament\Blocks\EngagementBatchBlock;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
@@ -47,6 +51,8 @@ class CampaignAction extends BaseModel implements Auditable
         $response = match ($this->type) {
             CampaignActionType::BulkEngagement => EngagementBatch::executeFromCampaignAction($this),
             CampaignActionType::ServiceRequest => ServiceRequest::executeFromCampaignAction($this),
+            CampaignActionType::ProactiveAlert => Alert::executeFromCampaignAction($this),
+            CampaignActionType::Interaction => Interaction::executeFromCampaignAction($this),
             default => null
         };
 
@@ -89,6 +95,8 @@ class CampaignAction extends BaseModel implements Auditable
         return match ($this->type) {
             CampaignActionType::BulkEngagement => EngagementBatchBlock::make()->editFields(),
             CampaignActionType::ServiceRequest => ServiceRequestBlock::make()->editFields(),
+            CampaignActionType::ProactiveAlert => ProactiveAlertBlock::make()->editFields(),
+            CampaignActionType::Interaction => InteractionBlock::make()->editFields(),
             default => []
         };
     }

--- a/app-modules/campaign/tests/Actions/ProactiveAlertsCampaignTest.php
+++ b/app-modules/campaign/tests/Actions/ProactiveAlertsCampaignTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Assist\Alert\Models\Alert;
+use Assist\Campaign\Models\Campaign;
+use Assist\Prospect\Models\Prospect;
+use Assist\Campaign\Models\CampaignAction;
+use Assist\Campaign\Enums\CampaignActionType;
+use Assist\CaseloadManagement\Models\Caseload;
+use Assist\CaseloadManagement\Enums\CaseloadType;
+
+it('will create the appropriate records for educatables in the caseload', function () {
+    // Given we have no proactive alerts
+    expect(Alert::count())->toBe(0);
+
+    // But we have a caseload, a campaign, and an action that defines we should create an alert at a certain point in time
+    $prospects = Prospect::factory()->count(3)->create([
+        'first_name' => 'TestTest',
+    ]);
+
+    $caseload = Caseload::factory()->create([
+        'type' => CaseloadType::Static,
+    ]);
+
+    $prospects->each(function (Prospect $prospect) use ($caseload) {
+        $caseload->subjects()->create([
+            'subject_id' => $prospect->getKey(),
+            'subject_type' => $prospect->getMorphClass(),
+        ]);
+    });
+
+    $campaign = Campaign::factory()->create([
+        'caseload_id' => $caseload->id,
+    ]);
+
+    $action = CampaignAction::factory()
+        ->for($campaign, 'campaign')
+        ->create([
+            'type' => CampaignActionType::ProactiveAlert,
+            'data' => [
+                'description' => 'This is the description',
+                'severity' => 'low',
+                'suggested_intervention' => 'This is the suggested intervention',
+                'status' => 'active',
+            ],
+        ]);
+
+    // When that action runs
+    $action->execute();
+
+    // We should have created the appropriate alerts for the appropriate educatable records
+    expect(Alert::count())->toBe(3);
+});

--- a/app-modules/campaign/tests/Actions/ProactiveAlertsCampaignTest.php
+++ b/app-modules/campaign/tests/Actions/ProactiveAlertsCampaignTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use Assist\Alert\Models\Alert;
+use Assist\Alert\Enums\AlertStatus;
 use Assist\Campaign\Models\Campaign;
 use Assist\Prospect\Models\Prospect;
+use Assist\Alert\Enums\AlertSeverity;
 use Assist\Campaign\Models\CampaignAction;
 use Assist\Campaign\Enums\CampaignActionType;
 use Assist\CaseloadManagement\Models\Caseload;
@@ -49,4 +51,8 @@ it('will create the appropriate records for educatables in the caseload', functi
 
     // We should have created the appropriate alerts for the appropriate educatable records
     expect(Alert::count())->toBe(3);
+    expect(Alert::first()->description)->toBe('This is the description');
+    expect(Alert::first()->severity)->toBe(AlertSeverity::Low);
+    expect(Alert::first()->suggested_intervention)->toBe('This is the suggested intervention');
+    expect(Alert::first()->status)->toBe(AlertStatus::Active);
 });

--- a/app-modules/care-team/src/Models/CareTeam.php
+++ b/app-modules/care-team/src/Models/CareTeam.php
@@ -11,6 +11,9 @@ use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Assist\AssistDataModel\Models\Contracts\Educatable;
 use Assist\Authorization\Models\Concerns\DefinesPermissions;
 
+/**
+ * @mixin IdeHelperCareTeam
+ */
 class CareTeam extends MorphPivot
 {
     use HasFactory;

--- a/app-modules/caseload-management/src/Models/Caseload.php
+++ b/app-modules/caseload-management/src/Models/Caseload.php
@@ -45,7 +45,9 @@ class Caseload extends BaseModel
     public function retrieveRecords(): Collection
     {
         if (count($this->subjects) > 0) {
-            return $this->subjects;
+            return $this->subjects->map(function (CaseloadSubject $subject) {
+                return $subject->subject;
+            });
         }
 
         /** @var Builder $modelQueryBuilder */

--- a/app-modules/caseload-management/src/Models/CaseloadSubject.php
+++ b/app-modules/caseload-management/src/Models/CaseloadSubject.php
@@ -11,6 +11,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class CaseloadSubject extends BaseModel
 {
+    protected $fillable = [
+        'subject_id',
+        'subject_type',
+    ];
+
     public function caseload(): BelongsTo
     {
         return $this->belongsTo(Caseload::class);

--- a/app-modules/interaction/src/Models/Interaction.php
+++ b/app-modules/interaction/src/Models/Interaction.php
@@ -6,16 +6,19 @@ use App\Models\BaseModel;
 use Illuminate\Support\Collection;
 use Assist\Division\Models\Division;
 use OwenIt\Auditing\Contracts\Auditable;
+use Assist\Campaign\Models\CampaignAction;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Assist\AssistDataModel\Models\Contracts\Educatable;
 use Assist\Notifications\Models\Contracts\Subscribable;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
+use Assist\Campaign\Models\Contracts\ExecutableFromACampaignAction;
 use Assist\Notifications\Models\Contracts\CanTriggerAutoSubscription;
 
 /**
  * @mixin IdeHelperInteraction
  */
-class Interaction extends BaseModel implements Auditable, CanTriggerAutoSubscription
+class Interaction extends BaseModel implements Auditable, CanTriggerAutoSubscription, ExecutableFromACampaignAction
 {
     use AuditableTrait;
 
@@ -93,5 +96,31 @@ class Interaction extends BaseModel implements Auditable, CanTriggerAutoSubscrip
     public function type(): BelongsTo
     {
         return $this->belongsTo(InteractionType::class, 'interaction_type_id');
+    }
+
+    public static function executeFromCampaignAction(CampaignAction $action): bool|string
+    {
+        try {
+            $action->campaign->caseload->retrieveRecords()->each(function (Educatable $educatable) use ($action) {
+                Interaction::create([
+                    'user_id' => $action->campaign->user_id,
+                    'interactable_type' => $educatable->getMorphClass(),
+                    'interactable_id' => $educatable->getKey(),
+                    'interaction_type_id' => $action->data['interaction_type_id'],
+                    'interaction_relation_id' => $action->data['interaction_relation_id'],
+                    'interaction_campaign_id' => $action->data['interaction_campaign_id'],
+                    'interaction_driver_id' => $action->data['interaction_driver_id'],
+                    'interaction_status_id' => $action->data['interaction_status_id'],
+                    'interaction_outcome_id' => $action->data['interaction_outcome_id'],
+                    'division_id' => $action->data['division_id'],
+                ]);
+            });
+
+            return true;
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+
+        // Do we need to be able to relate campaigns/actions to the RESULT of their actions?
     }
 }

--- a/app-modules/interaction/src/Models/Interaction.php
+++ b/app-modules/interaction/src/Models/Interaction.php
@@ -2,6 +2,7 @@
 
 namespace Assist\Interaction\Models;
 
+use Exception;
 use App\Models\BaseModel;
 use Illuminate\Support\Collection;
 use Assist\Division\Models\Division;

--- a/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
@@ -18,7 +18,7 @@
                 @endforeach
             </dd>
         </div>
-        <div class="flex flex-col py-3">
+        <div class="flex flex-col pt-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Subject</dt>
             <dd class="text-sm font-semibold">{{ $action['subject'] }}</dd>
         </div>

--- a/resources/views/filament/forms/components/campaigns/actions/interaction.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/interaction.blade.php
@@ -1,0 +1,73 @@
+@php
+    use Carbon\Carbon;
+    use Assist\Division\Models\Division;
+    use Assist\Interaction\Models\InteractionType;
+    use Assist\Interaction\Models\InteractionStatus;
+    use Assist\Interaction\Models\InteractionDriver;
+    use Assist\Interaction\Models\InteractionOutcome;
+    use Assist\Interaction\Models\InteractionCampaign;
+    use Assist\Interaction\Models\InteractionRelation;
+@endphp
+
+<x-filament::fieldset>
+    <x-slot name="label">
+        Interaction
+    </x-slot>
+
+    <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
+        <div class="flex flex-col pb-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Campaign</dt>
+            <dd class="text-sm font-semibold">{{ InteractionCampaign::find($action['interaction_campaign_id'])?->name }}
+            </dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Driver</dt>
+            <dd class="text-sm font-semibold">{{ InteractionDriver::find($action['interaction_driver_id'])?->name }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Division</dt>
+            <dd class="text-sm font-semibold">{{ Division::find($action['division_id'])?->name }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Outcome</dt>
+            <dd class="text-sm font-semibold">{{ InteractionOutcome::find($action['interaction_outcome_id'])?->name }}
+            </dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Relation</dt>
+            <dd class="text-sm font-semibold">{{ InteractionRelation::find($action['interaction_relation_id'])?->name }}
+            </dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Status</dt>
+            <dd class="text-sm font-semibold">{{ InteractionStatus::find($action['interaction_status_id'])?->name }}
+            </dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Type</dt>
+            <dd class="text-sm font-semibold">{{ InteractionType::find($action['interaction_type_id'])?->name }}
+            </dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Start Time</dt>
+            <dd class="text-sm font-semibold">{{ Carbon::parse($action['start_datetime'])->format('m/d/Y H:i:s') }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">End Time</dt>
+            <dd class="text-sm font-semibold">{{ Carbon::parse($action['end_datetime'])->format('m/d/Y H:i:s') }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Subject</dt>
+            <dd class="text-sm font-semibold">{{ $action['subject'] }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Description</dt>
+            <dd class="text-sm font-semibold">{{ $action['description'] }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Execute At</dt>
+            <dd class="text-sm font-semibold">{{ Carbon::parse($action['execute_at'])->format('m/d/Y H:i:s') }}</dd>
+        </div>
+    </dl>
+
+</x-filament::fieldset>

--- a/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
@@ -8,7 +8,7 @@
     </x-slot>
 
     <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
-        <div class="flex flex-col py-3">
+        <div class="flex flex-col pb-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Description</dt>
             <dd class="text-sm font-semibold">{{ $action['description'] }}</dd>
         </div>

--- a/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
@@ -1,0 +1,33 @@
+@php
+    use Carbon\Carbon;
+@endphp
+
+<x-filament::fieldset>
+    <x-slot name="label">
+        Proactive Alert
+    </x-slot>
+
+    <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
+        <div class="flex flex-col py-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Description</dt>
+            <dd class="text-sm font-semibold">{{ $action['description'] }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Severity</dt>
+            <dd class="text-sm font-semibold">{{ $action['severity'] }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Status</dt>
+            <dd class="text-sm font-semibold">{{ $action['status'] }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Suggested Intervention</dt>
+            <dd class="text-sm font-semibold">{{ $action['suggested_intervention'] }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Execute At</dt>
+            <dd class="text-sm font-semibold">{{ Carbon::parse($action['execute_at'])->format('m/d/Y H:i:s') }}</dd>
+        </div>
+    </dl>
+
+</x-filament::fieldset>

--- a/resources/views/filament/forms/components/campaigns/actions/service-request.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/service-request.blade.php
@@ -13,7 +13,7 @@
     </x-slot>
 
     <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
-        <div class="flex flex-col py-3">
+        <div class="flex flex-col pb-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Division</dt>
             <dd class="text-sm font-semibold">{{ Division::find($action['division_id'])?->name }}</dd>
         </div>

--- a/resources/views/filament/forms/components/campaigns/step-summary.blade.php
+++ b/resources/views/filament/forms/components/campaigns/step-summary.blade.php
@@ -15,6 +15,7 @@
                 $view = match ($action['type']) {
                     CampaignActionType::BulkEngagement->value => 'filament.forms.components.campaigns.actions.bulk-engagement',
                     CampaignActionType::ServiceRequest->value => 'filament.forms.components.campaigns.actions.service-request',
+                    CampaignActionType::ProactiveAlert->value => 'filament.forms.components.campaigns.actions.proactive-alert',
                 };
             @endphp
 

--- a/resources/views/filament/forms/components/campaigns/step-summary.blade.php
+++ b/resources/views/filament/forms/components/campaigns/step-summary.blade.php
@@ -16,6 +16,7 @@
                     CampaignActionType::BulkEngagement->value => 'filament.forms.components.campaigns.actions.bulk-engagement',
                     CampaignActionType::ServiceRequest->value => 'filament.forms.components.campaigns.actions.service-request',
                     CampaignActionType::ProactiveAlert->value => 'filament.forms.components.campaigns.actions.proactive-alert',
+                    CampaignActionType::Interaction->value => 'filament.forms.components.campaigns.actions.interaction',
                 };
             @endphp
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/company/personal/user/15/tasks/task/view/721/
https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/803/

### Technical Description

This PR covers adding campaign types for both the `Alert` and `Interaction` models.

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.