### PR TITLE
[ASSIST-805]: Add a new campaign type for Care Team

### DIFF
--- a/app-modules/assist-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/assist-data-model/src/Models/Contracts/Educatable.php
@@ -2,7 +2,11 @@
 
 namespace Assist\AssistDataModel\Models\Contracts;
 
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
 interface Educatable extends Identifiable
 {
     public static function displayNameKey(): string;
+
+    public function careTeam(): MorphToMany;
 }

--- a/app-modules/assist-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/assist-data-model/src/Models/Contracts/Educatable.php
@@ -2,8 +2,12 @@
 
 namespace Assist\AssistDataModel\Models\Contracts;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
+/**
+* @property-read Collection $careTeam
+ */
 interface Educatable extends Identifiable
 {
     public static function displayNameKey(): string;

--- a/app-modules/campaign/src/Enums/CampaignActionType.php
+++ b/app-modules/campaign/src/Enums/CampaignActionType.php
@@ -14,12 +14,15 @@ enum CampaignActionType: string implements HasLabel
 
     case Interaction = 'interaction';
 
+    case CareTeam = 'care_team';
+
     public function getLabel(): ?string
     {
         return match ($this) {
             CampaignActionType::BulkEngagement => 'Bulk Engagement',
             CampaignActionType::ServiceRequest => 'Service Request',
             CampaignActionType::ProactiveAlert => 'Proactive Alert',
+            CampaignActionType::CareTeam => 'Care Team',
             default => $this->name,
         };
     }

--- a/app-modules/campaign/src/Filament/Blocks/CareTeamBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/CareTeamBlock.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Assist\Campaign\Filament\Blocks;
+
+use App\Models\User;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\DateTimePicker;
+
+class CareTeamBlock extends CampaignActionBlock
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Care Team');
+
+        $this->schema($this->createFields());
+    }
+
+    public function generateFields(string $fieldPrefix = ''): array
+    {
+        return [
+            Select::make($fieldPrefix . 'user_ids')
+                ->label('Who should be assigned to the care team?')
+                ->options(User::all()->pluck('name', 'id'))
+                ->multiple()
+                ->searchable()
+                ->default([auth()->user()->id])
+                ->required()
+                ->exists('users', 'id'),
+            Toggle::make($fieldPrefix . 'remove_prior')
+                ->label('Remove all prior care team assignments?')
+                ->default(false)
+                ->hintIconTooltip('If checked, all prior care team assignments will be removed.'),
+            DateTimePicker::make($fieldPrefix . 'execute_at')
+                ->label('When should the action be executed?')
+                ->required()
+                ->minDate(now(auth()->user()->timezone))
+                ->closeOnDateSelection(),
+        ];
+    }
+
+    public static function type(): string
+    {
+        return 'care_team';
+    }
+}

--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ViewField;
 use Filament\Forms\Components\Wizard\Step;
 use Filament\Resources\Pages\CreateRecord;
+use Assist\Campaign\Filament\Blocks\CareTeamBlock;
 use Assist\Campaign\Actions\CreateActionsForCampaign;
 use Assist\Campaign\Filament\Blocks\InteractionBlock;
 use Assist\Campaign\Filament\Blocks\ProactiveAlertBlock;
@@ -34,6 +35,7 @@ class CreateCampaign extends CreateRecord
             ServiceRequestBlock::make(),
             ProactiveAlertBlock::make(),
             InteractionBlock::make(),
+            CareTeamBlock::make(),
         ];
     }
 
@@ -75,7 +77,10 @@ class CreateCampaign extends CreateRecord
 
     protected function handleRecordCreation(array $data): Model
     {
-        $campaign = static::getModel()::create($data);
+        /** @var Model $model */
+        $model = static::getModel();
+
+        $campaign = $model::query()->create($data);
 
         resolve(CreateActionsForCampaign::class)->from(
             $campaign,

--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/RelationManagers/CampaignActionsRelationManager.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/RelationManagers/CampaignActionsRelationManager.php
@@ -5,6 +5,7 @@ namespace Assist\Campaign\Filament\Resources\CampaignResource\RelationManagers;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use Assist\Alert\Models\Alert;
+use Assist\CareTeam\Models\CareTeam;
 use Filament\Forms\Components\Builder;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
@@ -34,7 +35,8 @@ class CampaignActionsRelationManager extends RelationManager
             CampaignActionType::BulkEngagement => EngagementBatch::class,
             CampaignActionType::ServiceRequest => ServiceRequest::class,
             CampaignActionType::ProactiveAlert => Alert::class,
-            CampaignActionType::Interaction => Interaction::class
+            CampaignActionType::Interaction => Interaction::class,
+            CampaignActionType::CareTeam => CareTeam::class
         };
 
         return $form

--- a/app-modules/campaign/src/Models/CampaignAction.php
+++ b/app-modules/campaign/src/Models/CampaignAction.php
@@ -4,11 +4,13 @@ namespace Assist\Campaign\Models;
 
 use App\Models\BaseModel;
 use Assist\Alert\Models\Alert;
+use Assist\CareTeam\Models\CareTeam;
 use OwenIt\Auditing\Contracts\Auditable;
 use Assist\Interaction\Models\Interaction;
 use Assist\Campaign\Enums\CampaignActionType;
 use Assist\Engagement\Models\EngagementBatch;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Assist\Campaign\Filament\Blocks\CareTeamBlock;
 use Assist\ServiceManagement\Models\ServiceRequest;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Assist\Campaign\Filament\Blocks\InteractionBlock;
@@ -53,6 +55,7 @@ class CampaignAction extends BaseModel implements Auditable
             CampaignActionType::ServiceRequest => ServiceRequest::executeFromCampaignAction($this),
             CampaignActionType::ProactiveAlert => Alert::executeFromCampaignAction($this),
             CampaignActionType::Interaction => Interaction::executeFromCampaignAction($this),
+            CampaignActionType::CareTeam => CareTeam::executeFromCampaignAction($this),
             default => null
         };
 
@@ -97,6 +100,7 @@ class CampaignAction extends BaseModel implements Auditable
             CampaignActionType::ServiceRequest => ServiceRequestBlock::make()->editFields(),
             CampaignActionType::ProactiveAlert => ProactiveAlertBlock::make()->editFields(),
             CampaignActionType::Interaction => InteractionBlock::make()->editFields(),
+            CampaignActionType::CareTeam => CareTeamBlock::make()->editFields(),
             default => []
         };
     }

--- a/app-modules/campaign/tests/Actions/CareTeamCampaignTest.php
+++ b/app-modules/campaign/tests/Actions/CareTeamCampaignTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Models\User;
+use Assist\Campaign\Models\Campaign;
+use Assist\Prospect\Models\Prospect;
+use Assist\AssistDataModel\Models\Student;
+use Assist\Campaign\Models\CampaignAction;
+use Illuminate\Database\Eloquent\Collection;
+use Assist\Campaign\Enums\CampaignActionType;
+use Assist\CaseloadManagement\Models\Caseload;
+use Assist\CaseloadManagement\Enums\CaseloadType;
+use Assist\AssistDataModel\Models\Contracts\Educatable;
+
+it('will create the appropriate records for educatables in the caseload', function (array $priorCareTeam, Collection $educatables, bool $removePrior) {
+    $caseload = Caseload::factory()->create([
+        'type' => CaseloadType::Static,
+    ]);
+
+    $educatables->each(function (Educatable $educatable) use ($caseload, $priorCareTeam) {
+        $caseload->subjects()->create([
+            'subject_id' => $educatable->getKey(),
+            'subject_type' => $educatable->getMorphClass(),
+        ]);
+
+        $educatable->careTeam()->sync($priorCareTeam);
+    });
+
+    $campaign = Campaign::factory()->create([
+        'caseload_id' => $caseload->id,
+    ]);
+
+    $users = User::factory()->count(3)->create();
+
+    $action = CampaignAction::factory()
+        ->for($campaign, 'campaign')
+        ->create([
+            'type' => CampaignActionType::CareTeam,
+            'data' => [
+                'user_ids' => $users->pluck('id')->toArray(),
+                'remove_prior' => $removePrior,
+            ],
+        ]);
+
+    // When that action runs
+    $action->execute();
+
+    $educatables->each(
+        fn (Educatable $educatable) => expect(
+            $educatable->careTeam->pluck('id')->toArray()
+        )
+            ->toBe(
+                $removePrior
+                    ? $users->pluck('id')->toArray()
+                    : [...$priorCareTeam, ...$users->pluck('id')->toArray()]
+            )
+    );
+})->with(
+    [
+        'no prior care team | prospects | remove prior false' => [
+            'priorCareTeam' => [],
+            'educatables' => fn () => Prospect::factory()->count(3)->create(),
+            'removePrior' => false,
+        ],
+        'no prior care team | prospects | remove prior true' => [
+            'priorCareTeam' => [],
+            'educatables' => fn () => Prospect::factory()->count(3)->create(),
+            'removePrior' => true,
+        ],
+        'prior care team | prospects | remove prior false' => [
+            'priorCareTeam' => fn () => User::factory()->count(3)->create()->pluck('id')->toArray(),
+            'educatables' => fn () => Prospect::factory()->count(3)->create(),
+            'removePrior' => false,
+        ],
+        'prior care team | prospects | remove prior true' => [
+            'priorCareTeam' => fn () => User::factory()->count(3)->create()->pluck('id')->toArray(),
+            'educatables' => fn () => Prospect::factory()->count(3)->create(),
+            'removePrior' => true,
+        ],
+        'no prior care team | students | remove prior false' => [
+            'priorCareTeam' => [],
+            'educatables' => fn () => Student::factory()->count(3)->create(),
+            'removePrior' => false,
+        ],
+        'no prior care team | students | remove prior true' => [
+            'priorCareTeam' => [],
+            'educatables' => fn () => Student::factory()->count(3)->create(),
+            'removePrior' => true,
+        ],
+        'prior care team | students | remove prior false' => [
+            'priorCareTeam' => fn () => User::factory()->count(3)->create()->pluck('id')->toArray(),
+            'educatables' => fn () => Student::factory()->count(3)->create(),
+            'removePrior' => false,
+        ],
+        'prior care team | students | remove prior true' => [
+            'priorCareTeam' => fn () => User::factory()->count(3)->create()->pluck('id')->toArray(),
+            'educatables' => fn () => Student::factory()->count(3)->create(),
+            'removePrior' => true,
+        ],
+    ]
+);

--- a/app-modules/care-team/src/Models/CareTeam.php
+++ b/app-modules/care-team/src/Models/CareTeam.php
@@ -2,7 +2,10 @@
 
 namespace Assist\CareTeam\Models;
 
+use Exception;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Assist\Campaign\Models\CampaignAction;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,11 +13,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Assist\AssistDataModel\Models\Contracts\Educatable;
 use Assist\Authorization\Models\Concerns\DefinesPermissions;
+use Assist\Campaign\Models\Contracts\ExecutableFromACampaignAction;
 
 /**
  * @mixin IdeHelperCareTeam
  */
-class CareTeam extends MorphPivot
+class CareTeam extends MorphPivot implements ExecutableFromACampaignAction
 {
     use HasFactory;
     use DefinesPermissions;
@@ -33,5 +37,26 @@ class CareTeam extends MorphPivot
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class)->withTimestamps();
+    }
+
+    public static function executeFromCampaignAction(CampaignAction $action): bool|string
+    {
+        try {
+            DB::beginTransaction();
+
+            $action->campaign->caseload->retrieveRecords()->each(function (Educatable $educatable) use ($action) {
+                $educatable->careTeam()->sync(ids: $action->data['user_ids'], detaching: $action->data['remove_prior']);
+            });
+
+            DB::commit();
+
+            return true;
+        } catch (Exception $e) {
+            DB::rollBack();
+
+            return $e->getMessage();
+        }
+
+        // Do we need to be able to relate campaigns/actions to the RESULT of their actions?
     }
 }

--- a/resources/views/filament/forms/components/campaigns/actions/care-team.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/care-team.blade.php
@@ -18,7 +18,9 @@
     <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
         <div class="flex flex-col pb-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Users to be assigned to the care team</dt>
-            <dd class="text-sm font-semibold">{{ collect($action['user_ids'])->map(fn (string $userId): User => User::findOrFail($userId))->implode('name', ', ') }}</dd>
+            <dd class="text-sm font-semibold">
+                {{ collect($action['user_ids'])->map(fn(string $userId): User => User::findOrFail($userId))->implode('name', ', ') }}
+            </dd>
         </div>
         <div class="flex flex-col pb-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Remove all prior care team assignments</dt>

--- a/resources/views/filament/forms/components/campaigns/actions/care-team.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/care-team.blade.php
@@ -1,5 +1,6 @@
 @php
     use Carbon\Carbon;
+    use App\Models\User;
     use Assist\Division\Models\Division;
     use Assist\Interaction\Models\InteractionType;
     use Assist\Interaction\Models\InteractionStatus;
@@ -17,7 +18,7 @@
     <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
         <div class="flex flex-col pb-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Users to be assigned to the care team</dt>
-            <dd class="text-sm font-semibold">{{ implode(', ', $action['user_ids']) }}</dd>
+            <dd class="text-sm font-semibold">{{ collect($action['user_ids'])->map(fn (string $userId): User => User::findOrFail($userId))->implode('name', ', ') }}</dd>
         </div>
         <div class="flex flex-col pb-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Remove all prior care team assignments</dt>

--- a/resources/views/filament/forms/components/campaigns/actions/care-team.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/care-team.blade.php
@@ -1,0 +1,32 @@
+@php
+    use Carbon\Carbon;
+    use Assist\Division\Models\Division;
+    use Assist\Interaction\Models\InteractionType;
+    use Assist\Interaction\Models\InteractionStatus;
+    use Assist\Interaction\Models\InteractionDriver;
+    use Assist\Interaction\Models\InteractionOutcome;
+    use Assist\Interaction\Models\InteractionCampaign;
+    use Assist\Interaction\Models\InteractionRelation;
+@endphp
+
+<x-filament::fieldset>
+    <x-slot name="label">
+        Interaction
+    </x-slot>
+
+    <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
+        <div class="flex flex-col pb-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Users to be assigned to the care team</dt>
+            <dd class="text-sm font-semibold">{{ implode(', ', $action['user_ids']) }}</dd>
+        </div>
+        <div class="flex flex-col pb-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Remove all prior care team assignments</dt>
+            <dd class="text-sm font-semibold">{{ $action['remove_prior'] ? 'True' : 'False' }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Execute At</dt>
+            <dd class="text-sm font-semibold">{{ Carbon::parse($action['execute_at'])->format('m/d/Y H:i:s') }}</dd>
+        </div>
+    </dl>
+
+</x-filament::fieldset>

--- a/resources/views/filament/forms/components/campaigns/step-summary.blade.php
+++ b/resources/views/filament/forms/components/campaigns/step-summary.blade.php
@@ -17,6 +17,7 @@
                     CampaignActionType::ServiceRequest->value => 'filament.forms.components.campaigns.actions.service-request',
                     CampaignActionType::ProactiveAlert->value => 'filament.forms.components.campaigns.actions.proactive-alert',
                     CampaignActionType::Interaction->value => 'filament.forms.components.campaigns.actions.interaction',
+                    CampaignActionType::CareTeam->value => 'filament.forms.components.campaigns.actions.care-team',
                 };
             @endphp
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/805/

### Technical Description

Adds a Campaign Action to add or reset the CareTeam of Educatables in a CaseLoad.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.