### PR TITLE
[ASSIST-329]: Enable confirmation when cancelling bulk engagement

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -2,9 +2,8 @@
 
 namespace Assist\Engagement\Filament\Actions;
 
-use Livewire\Component;
-use Filament\Actions\Action;
 use Illuminate\Support\Collection;
+use Filament\Tables\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Tables\Actions\BulkAction;
@@ -13,6 +12,7 @@ use Filament\Forms\Components\Wizard\Step;
 use Assist\Engagement\Actions\CreateEngagementBatch;
 use Assist\Engagement\Enums\EngagementDeliveryMethod;
 use Assist\Engagement\DataTransferObjects\EngagementBatchCreationData;
+use Assist\Prospect\Filament\Resources\ProspectResource\Pages\ListProspects;
 
 class BulkEngagementAction
 {
@@ -88,28 +88,7 @@ class BulkEngagementAction
             ->modalSubmitActionLabel('Send')
             ->modalCloseButton(false)
             ->closeModalByClickingAway(false)
-            // FIXME This is currently not working exactly as expected. Dan is taking a look and will report back
-            // ->modalCancelAction(
-            //     fn ($action) => Action::make('cancel')
-            //         ->requiresConfirmation()
-            //         ->modalDescription(fn () => 'The message has not been sent, are you sure you wish to return to the list view?')
-            //         ->cancelParentActions()
-            //         ->close()
-            // )
-            ->modalCancelAction(
-                fn () => Action::make('abc')
-                    ->action(fn () => ray('abc'))
-                    ->color('gray'),
-            )
-            // ->extraModalFooterActions([
-            //     Action::make('abc')
-            //         ->action(function (Action $action, Component $livewire) {
-            //             ray($action, $livewire);
-            //         })
-            //         ->color('gray'),
-            //     Action::make('edit')
-            //         ->url(fn (): string => filament()->getHomeUrl()),
-            // ])
+            ->modalCancelAction(fn (ListProspects $livewire) => $livewire->cancelEngageAction())
             ->deselectRecordsAfterCompletion();
     }
 }

--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -2,6 +2,7 @@
 
 namespace Assist\Engagement\Filament\Actions;
 
+use Livewire\Component;
 use Filament\Actions\Action;
 use Illuminate\Support\Collection;
 use Filament\Forms\Components\Select;
@@ -88,14 +89,27 @@ class BulkEngagementAction
             ->modalCloseButton(false)
             ->closeModalByClickingAway(false)
             // FIXME This is currently not working exactly as expected. Dan is taking a look and will report back
+            // ->modalCancelAction(
+            //     fn ($action) => Action::make('cancel')
+            //         ->requiresConfirmation()
+            //         ->modalDescription(fn () => 'The message has not been sent, are you sure you wish to return to the list view?')
+            //         ->cancelParentActions()
+            //         ->close()
+            // )
             ->modalCancelAction(
-                fn ($action) => Action::make('cancel')
-                    ->requiresConfirmation()
-                    ->modalDescription(fn () => 'The message has not been sent, are you sure you wish to return to the list view?')
-                    ->cancelParentActions()
-                    ->close()
+                fn () => Action::make('abc')
+                    ->action(fn () => ray('abc'))
                     ->color('gray'),
             )
+            // ->extraModalFooterActions([
+            //     Action::make('abc')
+            //         ->action(function (Action $action, Component $livewire) {
+            //             ray($action, $livewire);
+            //         })
+            //         ->color('gray'),
+            //     Action::make('edit')
+            //         ->url(fn (): string => filament()->getHomeUrl()),
+            // ])
             ->deselectRecordsAfterCompletion();
     }
 }

--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -3,7 +3,6 @@
 namespace Assist\Engagement\Filament\Actions;
 
 use Illuminate\Support\Collection;
-use Filament\Tables\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Tables\Actions\BulkAction;

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -8,6 +8,7 @@ use Filament\Tables\Table;
 use Filament\Actions\Action;
 use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
+use Filament\Actions\StaticAction;
 use Filament\Tables\Filters\Filter;
 use Assist\Prospect\Models\Prospect;
 use Filament\Forms\Components\Radio;
@@ -236,6 +237,7 @@ class ListProspects extends ListRecords
                 $this->unmountTableBulkAction();
             })
             ->requiresConfirmation()
+            ->modalSubmitAction(fn (StaticAction $action) => $action->color('danger'))
             ->action(function () {
                 $this->engageActionData = [];
                 $this->engageActionRecords = [];

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -5,6 +5,7 @@ namespace Assist\Prospect\Filament\Resources\ProspectResource\Pages;
 use App\Models\User;
 use Filament\Forms\Get;
 use Filament\Tables\Table;
+use Filament\Actions\Action;
 use App\Filament\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Filters\Filter;
@@ -45,6 +46,10 @@ class ListProspects extends ListRecords
     use FilterTableWithOpenSearch;
 
     protected static string $resource = ProspectResource::class;
+
+    public array $engageActionData = [];
+
+    public array $engageActionRecords = [];
 
     public function table(Table $table): Table
     {
@@ -217,6 +222,38 @@ class ListProspects extends ListRecords
                                 ->send();
                         }),
                 ]),
+            ]);
+    }
+
+    public function cancelEngageAction(): Action
+    {
+        return Action::make('cancelEngage')
+            ->label('Cancel')
+            ->mountUsing(function () {
+                $this->engageActionData = $this->mountedTableBulkActionData;
+                $this->engageActionRecords = $this->selectedTableRecords;
+
+                $this->unmountTableBulkAction();
+            })
+            ->requiresConfirmation()
+            ->action(function () {
+                $this->engageActionData = [];
+                $this->engageActionRecords = [];
+            })
+            ->modalDescription(fn () => 'The message has not been sent, are you sure you wish to return to the list view?')
+            ->closeModalByClickingAway(false)
+            ->modalCloseButton(false)
+            ->modalCancelAction(false)
+            ->extraModalFooterActions([
+                Action::make('restoreEngageBulkAction')
+                    ->label('Cancel')
+                    ->action(function () {
+                        $this->mountTableBulkAction('engage');
+
+                        $this->mountedTableBulkActionData = $this->engageActionData;
+                        $this->selectedTableRecords = $this->engageActionRecords;
+                    })
+                    ->cancelParentActions(),
             ]);
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/329/

### Technical Description

Enable confirmation when cancelling bulk engagement.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.