### PR TITLE
[ASSIST-601]: Add "scheduled" column to Engagements

### DIFF
--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -128,6 +128,13 @@ class EngagementsRelationManager extends RelationManager
             ])
             ->headerActions([
                 CreateAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        if ($data['scheduled'] === false) {
+                            $data['scheduled'] = true;
+                        }
+
+                        return $data;
+                    })
                     ->after(function (Engagement $engagement, array $data) {
                         $this->afterCreate($engagement, $data['delivery_methods']);
                     }),

--- a/app-modules/engagement/database/factories/EngagementFactory.php
+++ b/app-modules/engagement/database/factories/EngagementFactory.php
@@ -105,4 +105,11 @@ class EngagementFactory extends Factory
             'engagement_batch_id' => EngagementBatch::factory(),
         ]);
     }
+
+    public function scheduled(): self
+    {
+        return $this->state([
+            'scheduled' => true,
+        ]);
+    }
 }

--- a/app-modules/engagement/database/migrations/2023_08_17_161256_create_engagements_table.php
+++ b/app-modules/engagement/database/migrations/2023_08_17_161256_create_engagements_table.php
@@ -43,6 +43,7 @@ return new class () extends Migration {
             $table->string('recipient_type')->nullable();
             $table->string('subject')->nullable();
             $table->longText('body')->nullable();
+            $table->boolean('scheduled')->default(false);
             $table->timestamp('deliver_at');
             $table->timestamps();
         });

--- a/app-modules/engagement/src/Actions/DeliverEngagements.php
+++ b/app-modules/engagement/src/Actions/DeliverEngagements.php
@@ -45,14 +45,13 @@ class DeliverEngagements implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    // TODO Add another indicator to the engagements table to represent an engagement being scheduled
-    // This will allow us to scope this query down further, and prevent any overlap with sync dispatches
     public function handle(): void
     {
         Engagement::query()
             ->where('deliver_at', '<=', now())
-            ->hasNotBeenDelivered()
+            ->isScheduled()
             ->isNotPartOfABatch()
+            ->hasNotBeenDelivered()
             ->cursor()
             ->each(function (Engagement $engagement) {
                 $engagement->deliverables()->each(function (EngagementDeliverable $deliverable) {

--- a/app-modules/engagement/src/Filament/Actions/Concerns/ImplementsHasBulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/Concerns/ImplementsHasBulkEngagementAction.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\Engagement\Filament\Actions\Concerns;
 
 use Filament\Actions\Action;

--- a/app-modules/engagement/src/Filament/Actions/Contracts/HasBulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/Contracts/HasBulkEngagementAction.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\Engagement\Filament\Actions\Contracts;
 
 use Filament\Actions\Action;

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
@@ -120,4 +120,13 @@ class CreateEngagement extends CreateRecord
 
         $createDeliverablesForEngagement($this->record, $this->data['delivery_methods']);
     }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if ($data['scheduled'] === false) {
+            $data['scheduled'] = true;
+        }
+
+        return $data;
+    }
 }

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
@@ -104,12 +104,12 @@ class CreateEngagement extends CreateRecord
                     ]),
                 Fieldset::make('Send your engagement')
                     ->schema([
-                        Toggle::make('send_later')
+                        Toggle::make('scheduled')
                             ->reactive()
                             ->helperText('By default, this engagement will send as soon as it is created unless you schedule it to send later.'),
                         DateTimePicker::make('deliver_at')
                             ->required()
-                            ->visible(fn (callable $get) => $get('send_later')),
+                            ->visible(fn (callable $get) => $get('scheduled')),
                     ]),
             ]);
     }

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
@@ -74,12 +74,12 @@ class EditEngagement extends EditRecord
                     ]),
                 Fieldset::make('Send your engagement')
                     ->schema([
-                        Toggle::make('send_later')
+                        Toggle::make('scheduled')
                             ->reactive()
                             ->helperText('By default, this engagement will send as soon as it is created unless you schedule it to send later.'),
                         DateTimePicker::make('deliver_at')
                             ->required()
-                            ->visible(fn (callable $get) => $get('send_later')),
+                            ->visible(fn (callable $get) => $get('scheduled')),
                     ]),
             ]);
     }

--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -66,11 +66,13 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
         'body',
         'recipient_id',
         'recipient_type',
+        'scheduled',
         'deliver_at',
     ];
 
     protected $casts = [
         'deliver_at' => 'datetime',
+        'scheduled' => 'boolean',
     ];
 
     // TODO Consider changing this relationship if we ever needed to timeline something else where records might be shared across entities
@@ -126,6 +128,11 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
     public function batch(): BelongsTo
     {
         return $this->engagementBatch();
+    }
+
+    public function scopeIsScheduled(Builder $query): void
+    {
+        $query->where('scheduled', true);
     }
 
     public function scopeHasBeenDelivered(Builder $query): void

--- a/app-modules/engagement/tests/Feature/Actions/DeliverEngagementsTest.php
+++ b/app-modules/engagement/tests/Feature/Actions/DeliverEngagementsTest.php
@@ -145,7 +145,7 @@ it('will only dispatch a job to send an engagement that is scheduled', function 
     Queue::fake(EngagementEmailChannelDelivery::class);
     Notification::fake();
 
-    // Given that we have an engagement that is not scheduled
+    // Given that we have an engagement that is not scheduled but should otherwise be delivered
     Engagement::factory()
         ->deliverNow()
         ->has(EngagementDeliverable::factory()->email()->count(1))

--- a/app-modules/engagement/tests/Feature/Actions/DeliverEngagementsTest.php
+++ b/app-modules/engagement/tests/Feature/Actions/DeliverEngagementsTest.php
@@ -42,12 +42,14 @@ it('will dispatch a job to send all engagements that should be delivered via ema
 
     // Given that we have an engagement that should be delivered
     $engagement = Engagement::factory()
+        ->scheduled()
         ->deliverNow()
         ->has(EngagementDeliverable::factory()->email()->count(1))
         ->create();
 
     // And an engagement that shouldn't be sent until some point in the future
     $futureEngagement = Engagement::factory()
+        ->scheduled()
         ->deliverLater()
         ->has(EngagementDeliverable::factory()->email()->count(1))
         ->create();
@@ -70,12 +72,14 @@ it('will dispatch a job to send all engagements that should be delivered via sms
 
     // Given that we have an engagement that should be delivered
     $engagement = Engagement::factory()
+        ->scheduled()
         ->deliverNow()
         ->has(EngagementDeliverable::factory()->sms()->count(1))
         ->create();
 
     // And an engagement that shouldn't be sent until some point in the future
     $futureEngagement = Engagement::factory()
+        ->scheduled()
         ->deliverLater()
         ->has(EngagementDeliverable::factory()->sms()->count(1))
         ->create();
@@ -99,6 +103,7 @@ it('will not dispatch a job to send an engagement that has already been delivere
 
     // Given that we have an engagement
     $engagement = Engagement::factory()
+        ->scheduled()
         ->deliverNow()
         ->has(EngagementDeliverable::factory()->email()->count(1))
         ->create();
@@ -125,6 +130,23 @@ it('will not dispatch a job to send an engagement that is part of a batch', func
     // Given that we have an engagement
     $engagement = Engagement::factory()
         ->ofBatch()
+        ->deliverNow()
+        ->has(EngagementDeliverable::factory()->email()->count(1))
+        ->create();
+
+    // When our job runs to pick up engagements
+    DeliverEngagements::dispatchSync();
+
+    // This engagement should not be picked up and delivered
+    Queue::assertPushed(EngagementEmailChannelDelivery::class, 0);
+});
+
+it('will only dispatch a job to send an engagement that is scheduled', function () {
+    Queue::fake(EngagementEmailChannelDelivery::class);
+    Notification::fake();
+
+    // Given that we have an engagement that is not scheduled
+    Engagement::factory()
         ->deliverNow()
         ->has(EngagementDeliverable::factory()->email()->count(1))
         ->create();

--- a/app-modules/form/src/Events/FormSubmissionCreated.php
+++ b/app-modules/form/src/Events/FormSubmissionCreated.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\Form\Events;
 
 use Assist\Form\Models\FormSubmission;

--- a/app-modules/form/src/Listeners/NotifySubscribersOfFormSubmission.php
+++ b/app-modules/form/src/Listeners/NotifySubscribersOfFormSubmission.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\Form\Listeners;
 
 use Assist\Prospect\Models\Prospect;

--- a/app-modules/form/src/Notifications/AuthorLinkedFormSubmissionCreatedNotification.php
+++ b/app-modules/form/src/Notifications/AuthorLinkedFormSubmissionCreatedNotification.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\Form\Notifications;
 
 use App\Models\User;

--- a/app-modules/form/src/Observers/FormSubmissionObserver.php
+++ b/app-modules/form/src/Observers/FormSubmissionObserver.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\Form\Observers;
 
 use Illuminate\Support\Facades\Event;

--- a/app-modules/form/tests/FormSubmissionCreatedTest.php
+++ b/app-modules/form/tests/FormSubmissionCreatedTest.php
@@ -1,5 +1,33 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+Copyright © 2022-2023, Canyon GBS LLC
+
+All rights reserved.
+
+This file is part of a project developed using Laravel, which is an open-source framework for PHP.
+Canyon GBS LLC acknowledges and respects the copyright of Laravel and other open-source
+projects used in the development of this solution.
+
+This project is licensed under the Affero General Public License (AGPL) 3.0.
+For more details, see https://github.com/canyongbs/assistbycanyongbs/blob/main/LICENSE.
+
+Notice:
+- The copyright notice in this file and across all files and applications in this
+ repository cannot be removed or altered without violating the terms of the AGPL 3.0 License.
+- The software solution, including services, infrastructure, and code, is offered as a
+ Software as a Service (SaaS) by Canyon GBS LLC.
+- Use of this software implies agreement to the license terms and conditions as stated
+ in the AGPL 3.0 License.
+
+For more information or inquiries please visit our website at
+https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Assist\Form\Models\FormSubmission;

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
@@ -128,6 +128,13 @@ class EngagementsRelationManager extends RelationManager
             ])
             ->headerActions([
                 CreateAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        if ($data['scheduled'] === false) {
+                            $data['scheduled'] = true;
+                        }
+
+                        return $data;
+                    })
                     ->after(function (Engagement $engagement, array $data) {
                         $this->afterCreate($engagement, $data['delivery_methods']);
                     }),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/601/

### Technical Description

This PR adds a `scheduled` boolean column to the `engagements` table in order to make it easier to determine if an Engagement should be picked up in the "DeliverEngagements" job running in the Kernel.

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.